### PR TITLE
Add Defs and LinearGradient

### DIFF
--- a/example/SVGExampleList.js
+++ b/example/SVGExampleList.js
@@ -10,6 +10,7 @@ import {PathPage} from './examples/Path';
 import {PolygonPage} from './examples/Polygon';
 import {PolylinePage} from './examples/Polyline';
 import {ReusablePage} from './examples/Reusable';
+import {GradientsPage} from './examples/Gradients';
 
 interface ISVGExample {
   key: string;
@@ -56,6 +57,10 @@ export const SVGExampleList: Array<ISVGExample> = [
   {
     key: 'Reusable',
     component: ReusablePage,
+  },
+  {
+    key: 'Gradients',
+    component: GradientsPage,
   },
 ];
 

--- a/example/examples/Gradients.js
+++ b/example/examples/Gradients.js
@@ -1,0 +1,130 @@
+'use strict';
+import React from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import {View} from 'react-native';
+import {Svg, Defs, Ellipse, LinearGradient, Stop, Rect} from 'react-native-svg';
+
+export const GradientsPage: React.FunctionComponent<{}> = () => {
+  return (
+    <Page title="Gradients">
+      <Example title="Define an ellipse with a horizontal linear gradient from yellow to red">
+        <Svg height="150" width="300">
+          <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad-1)" />
+          <Defs>
+            <LinearGradient
+              id="grad-1"
+              x1="65"
+              y1="0"
+              x2="235"
+              y2="0"
+              gradientUnits="userSpaceOnUse">
+              <Stop offset="0" stopColor="rgb(255,255,0)" stopOpacity="1" />
+              <Stop offset="1" stopColor="red" />
+            </LinearGradient>
+          </Defs>
+        </Svg>
+      </Example>
+      <Example title="Define an ellipse with a horizontal linear gradient from transparent yellow to red, buggy on android and windows">
+        <Svg height="150" width="300">
+          <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad-1-bug)" />
+          <Defs>
+            <LinearGradient
+              id="grad-1-bug"
+              x1="65"
+              y1="0"
+              x2="235"
+              y2="0"
+              gradientUnits="userSpaceOnUse">
+              <Stop offset="0" stopColor="rgb(255,255,0)" stopOpacity="0" />
+              <Stop offset="1" stopColor="red" />
+            </LinearGradient>
+          </Defs>
+        </Svg>
+      </Example>
+      <Example title="Define an ellipse with a rotated linear gradient from yellow to red">
+        <Svg height="150" width="300">
+          <Defs>
+            <LinearGradient id="grad-2" x1={0} y1={0} x2="0%" y2="100%">
+              <Stop offset="0%" stopColor="rgb(255,255,0)" stopOpacity="1" />
+              <Stop offset="100%" stopColor="red" stopOpacity="1" />
+            </LinearGradient>
+          </Defs>
+          <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad-2)" />
+        </Svg>
+      </Example>
+      <Example title="Compare gradientUnits='userSpaceOnUse' with default">
+        <View
+          style={{
+            width: 300,
+            height: 150,
+            flexDirection: 'row',
+            justifyContent: 'space-around',
+          }}>
+          <Svg height="150" width="90">
+            <Defs>
+              <LinearGradient
+                id="defaultUnits"
+                x1="0%"
+                y1="0%"
+                x2="0%"
+                y2="100%">
+                <Stop offset="0%" stopColor="#000" stopOpacity="1" />
+                <Stop offset="100%" stopColor="#ff0" stopOpacity="1" />
+              </LinearGradient>
+            </Defs>
+            <Rect
+              fill="url(#defaultUnits)"
+              x="10"
+              y="10"
+              width="70"
+              height="70"
+              rx="10"
+              ry="10"
+            />
+          </Svg>
+          <Svg height="150" width="90">
+            <Defs>
+              <LinearGradient
+                id="userSpaceOnUse"
+                x1="0%"
+                y1="0%"
+                x2="0%"
+                y2="100%"
+                gradientUnits="userSpaceOnUse">
+                <Stop offset="0%" stopColor="#000" stopOpacity="1" />
+                <Stop offset="100%" stopColor="#ff0" stopOpacity="1" />
+              </LinearGradient>
+            </Defs>
+            <Rect
+              fill="url(#userSpaceOnUse)"
+              x="10"
+              y="10"
+              width="70"
+              height="70"
+              rx="10"
+              ry="10"
+            />
+          </Svg>
+        </View>
+      </Example>
+      <Example title="Define a linear gradient in percent unit">
+        <Svg height="150" width="300">
+          <Defs>
+            <LinearGradient id="grad-3" x1="0%" y1="0%" x2="100%" y2="0%">
+              <Stop offset="0%" stopColor="rgb(255,255,0)" stopOpacity="1" />
+              <Stop offset="100%" stopColor="red" stopOpacity="1" />
+            </LinearGradient>
+          </Defs>
+          {/* <Text x="25" y="70" fill="#333">
+            x1=0%
+          </Text>
+          <Text x="235" y="70" fill="#333">
+            x2=100%
+          </Text> */}
+          <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad-3)" />
+        </Svg>
+      </Example>
+    </Page>
+  );
+};

--- a/windows/RNSVG/BrushView.cpp
+++ b/windows/RNSVG/BrushView.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "BrushView.h"
+#include "BrushView.g.cpp"
+
+namespace winrt::RNSVG::implementation {
+void BrushView::SaveDefinition() {
+  if (auto const &root{SvgRoot()}) {
+    CreateBrush();
+    root.Brushes().Insert(Id(), *this);
+  }
+}
+
+void BrushView::SetBounds(Windows::Foundation::Rect const &rect) {
+  m_bounds = rect;
+  UpdateBounds();
+}
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/BrushView.h
+++ b/windows/RNSVG/BrushView.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "BrushView.g.h"
+#include "GroupView.h"
+
+namespace winrt::RNSVG::implementation {
+struct BrushView : BrushViewT<BrushView, RNSVG::implementation::GroupView> {
+ public:
+  BrushView() = default;
+
+  void SaveDefinition();
+
+  Microsoft::Graphics::Canvas::Brushes::ICanvasBrush Brush() { return m_brush; }
+  virtual void CreateBrush() {}
+  void SetBounds(Windows::Foundation::Rect const &rect);
+
+ protected:
+  Microsoft::Graphics::Canvas::Brushes::ICanvasBrush m_brush{nullptr};
+  Windows::Foundation::Rect m_bounds{};
+
+  virtual void UpdateBounds() {}
+};
+} // namespace winrt::RNSVG::implementation
+
+namespace winrt::RNSVG::factory_implementation {
+struct BrushView : BrushViewT<BrushView, implementation::BrushView> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/DefsView.cpp
+++ b/windows/RNSVG/DefsView.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+#include "DefsView.h"
+#include "DefsView.g.cpp"
+
+using namespace winrt;
+using namespace Microsoft::Graphics::Canvas;
+
+namespace winrt::RNSVG::implementation {
+void DefsView::Render(UI::Xaml::CanvasControl const &/*canvas*/, CanvasDrawingSession const &/*session*/) {
+  if (auto const &root{SvgRoot()}) {
+    for (auto const &child : Children()) {
+      if (auto const &defView{child.try_as<IDefinitionView>()}) {
+        defView.SaveDefinition();
+      } else if (child.Id() != L"") {
+        root.Templates().Insert(child.Id(), child);
+      }
+    }
+  }
+}
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/DefsView.cpp
+++ b/windows/RNSVG/DefsView.cpp
@@ -6,15 +6,5 @@ using namespace winrt;
 using namespace Microsoft::Graphics::Canvas;
 
 namespace winrt::RNSVG::implementation {
-void DefsView::Render(UI::Xaml::CanvasControl const &/*canvas*/, CanvasDrawingSession const &/*session*/) {
-  if (auto const &root{SvgRoot()}) {
-    for (auto const &child : Children()) {
-      if (auto const &defView{child.try_as<IDefinitionView>()}) {
-        defView.SaveDefinition();
-      } else if (child.Id() != L"") {
-        root.Templates().Insert(child.Id(), child);
-      }
-    }
-  }
-}
+void DefsView::Render(UI::Xaml::CanvasControl const &/*canvas*/, CanvasDrawingSession const &/*session*/) {}
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/DefsView.h
+++ b/windows/RNSVG/DefsView.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "DefsView.g.h"
+#include "GroupView.h"
+
+namespace winrt::RNSVG::implementation {
+struct DefsView : DefsViewT<DefsView, RNSVG::implementation::GroupView> {
+  DefsView() = default;
+
+  void Render(
+      Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
+      Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
+};
+} // namespace winrt::RNSVG::implementation
+
+namespace winrt::RNSVG::factory_implementation {
+struct DefsView : DefsViewT<DefsView, implementation::DefsView> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/DefsViewManager.cpp
+++ b/windows/RNSVG/DefsViewManager.cpp
@@ -1,0 +1,10 @@
+#include "pch.h"
+#include "DefsViewManager.h"
+#include "DefsViewManager.g.cpp"
+
+namespace winrt::RNSVG::implementation {
+DefsViewManager::DefsViewManager() {
+  m_class = RNSVG::SVGClass::RNSVGDefs;
+  m_name = L"RNSVGDefs";
+}
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/DefsViewManager.h
+++ b/windows/RNSVG/DefsViewManager.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "DefsViewManager.g.h"
+#include "GroupViewManager.h"
+
+namespace winrt::RNSVG::implementation {
+struct DefsViewManager : DefsViewManagerT<DefsViewManager, RNSVG::implementation::GroupViewManager> {
+  DefsViewManager();
+};
+} // namespace winrt::RNSVG::implementation
+namespace winrt::RNSVG::factory_implementation {
+struct DefsViewManager : DefsViewManagerT<DefsViewManager, implementation::DefsViewManager> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/GroupView.cpp
+++ b/windows/RNSVG/GroupView.cpp
@@ -116,13 +116,21 @@ void GroupView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate,
 }
 
 void GroupView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
-  auto resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
+  auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
   std::vector<Geometry::CanvasGeometry> geometries;
   for (auto const &child : Children()) {
     geometries.push_back(child.Geometry());
   }
 
   Geometry(Geometry::CanvasGeometry::CreateGroup(resourceCreator, geometries, FillRule()));
+}
+
+void GroupView::SaveDefinition() {
+  __super::SaveDefinition();
+
+  for (auto const &child : Children()) {
+    child.SaveDefinition();
+  }
 }
 
 void GroupView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSession const &session) {

--- a/windows/RNSVG/GroupView.h
+++ b/windows/RNSVG/GroupView.h
@@ -23,6 +23,8 @@ struct GroupView : GroupViewT<GroupView, RNSVG::implementation::RenderableView> 
   virtual void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
   virtual void CreateGeometry(Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas);
 
+  virtual void SaveDefinition();
+
   virtual void Render(
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
       Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);

--- a/windows/RNSVG/LinearGradientView.cpp
+++ b/windows/RNSVG/LinearGradientView.cpp
@@ -1,0 +1,44 @@
+#include "pch.h"
+#include "LinearGradientView.h"
+#include "LinearGradientView.g.cpp"
+
+#include "SVGLength.h"
+
+using namespace winrt;
+using namespace Microsoft::Graphics::Canvas;
+using namespace Microsoft::ReactNative;
+
+namespace winrt::RNSVG::implementation {
+void LinearGradientView::SaveDefinition() {
+  throw hresult_not_implemented();
+}
+
+void LinearGradientView::RemoveDefinition() {
+  throw hresult_not_implemented();
+}
+void LinearGradientView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
+  const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
+
+  for (auto const &pair : propertyMap) {
+    auto const &propertyName{pair.first};
+    auto const &propertyValue{pair.second};
+
+    if (propertyName == "name") {
+      RemoveDefinition();
+    } else if (propertyName == "x1") {
+      m_x1 = SVGLength::From(propertyValue);
+    } else if (propertyName == "y1") {
+      m_y1 = SVGLength::From(propertyValue);
+    } else if (propertyName == "x2") {
+      m_x2 = SVGLength::From(propertyValue);
+    } else if (propertyName == "y2") {
+      m_y2 = SVGLength::From(propertyValue);
+    }
+  }
+
+  __super::UpdateProperties(reader, forceUpdate, invalidate);
+}
+
+void LinearGradientView::Render(UI::Xaml::CanvasControl const &/*canvas*/, CanvasDrawingSession const &/*session*/) {}
+
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/LinearGradientView.cpp
+++ b/windows/RNSVG/LinearGradientView.cpp
@@ -2,20 +2,13 @@
 #include "LinearGradientView.h"
 #include "LinearGradientView.g.cpp"
 
-#include "SVGLength.h"
+#include "Utils.h"
 
 using namespace winrt;
 using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::ReactNative;
 
 namespace winrt::RNSVG::implementation {
-void LinearGradientView::SaveDefinition() {
-  throw hresult_not_implemented();
-}
-
-void LinearGradientView::RemoveDefinition() {
-  throw hresult_not_implemented();
-}
 void LinearGradientView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
   const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
 
@@ -23,9 +16,7 @@ void LinearGradientView::UpdateProperties(IJSValueReader const &reader, bool for
     auto const &propertyName{pair.first};
     auto const &propertyValue{pair.second};
 
-    if (propertyName == "name") {
-      RemoveDefinition();
-    } else if (propertyName == "x1") {
+    if (propertyName == "x1") {
       m_x1 = SVGLength::From(propertyValue);
     } else if (propertyName == "y1") {
       m_y1 = SVGLength::From(propertyValue);
@@ -33,12 +24,64 @@ void LinearGradientView::UpdateProperties(IJSValueReader const &reader, bool for
       m_x2 = SVGLength::From(propertyValue);
     } else if (propertyName == "y2") {
       m_y2 = SVGLength::From(propertyValue);
+    } else if (propertyName == "gradient") {
+      m_stops = Utils::JSValueAsStops(propertyValue);
+    } else if (propertyName == "gradientUnits") {
+      if (propertyValue.IsNull()) {
+        m_gradientUnits = "objectBoundingBox";
+      } else {
+        switch (propertyValue.AsInt32()) {
+          case 1:
+            m_gradientUnits = "userSpaceOnUse";
+            break;
+          case 0:
+          default:
+            m_gradientUnits = "objectBoundingBox";
+        }
+      }
+    } else if (propertyName == "gradientTransform") {
+      m_transformSet = true;
+      m_transform = Utils::JSValueAsTransform(propertyValue);
+
+      if (propertyValue.IsNull()) {
+        m_transformSet = false;
+      }
     }
   }
 
   __super::UpdateProperties(reader, forceUpdate, invalidate);
+
+  SaveDefinition();
 }
 
-void LinearGradientView::Render(UI::Xaml::CanvasControl const &/*canvas*/, CanvasDrawingSession const &/*session*/) {}
+void LinearGradientView::CreateBrush() {
+  auto const &canvas{SvgRoot().Canvas()};
+  auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
+  Brushes::CanvasLinearGradientBrush brush{resourceCreator, m_stops};
+
+  SetPoints(brush, {0, 0, canvas.Size().Width, canvas.Size().Height});
+
+  if (m_transformSet) {
+    brush.Transform(m_transform);
+  }
+
+  m_brush = brush;
+}
+
+void LinearGradientView::UpdateBounds() {
+  if (m_gradientUnits == "objectBoundingBox") {
+    SetPoints(m_brush.as<Brushes::CanvasLinearGradientBrush>(), m_bounds);
+  }
+}
+
+void LinearGradientView::SetPoints(Brushes::CanvasLinearGradientBrush brush, Windows::Foundation::Rect const &bounds) {
+  float x1{Utils::GetSvgLengthValue(m_x1, bounds.Width) + bounds.X};
+  float y1{Utils::GetSvgLengthValue(m_y1, bounds.Height) + bounds.Y};
+  float x2{Utils::GetSvgLengthValue(m_x2, bounds.Width) + bounds.X};
+  float y2{Utils::GetSvgLengthValue(m_y2, bounds.Height) + bounds.Y};
+
+  brush.StartPoint({x1, y1});
+  brush.EndPoint({x2, y2});
+}
 
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/LinearGradientView.h
+++ b/windows/RNSVG/LinearGradientView.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "LinearGradientView.g.h"
+#include "GroupView.h"
+
+namespace winrt::RNSVG::implementation {
+struct LinearGradientView : LinearGradientViewT<LinearGradientView, RNSVG::implementation::GroupView> {
+ public:
+  LinearGradientView() = default;
+
+  // IDefinitionView
+  void SaveDefinition();
+  void RemoveDefinition();
+
+  // RenderableView
+  void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
+  void Render(
+      Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
+      Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
+
+ private:
+  RNSVG::SVGLength m_x1{};
+  RNSVG::SVGLength m_y1{};
+  RNSVG::SVGLength m_x2{};
+  RNSVG::SVGLength m_y2{};
+};
+} // namespace winrt::RNSVG::implementation
+
+namespace winrt::RNSVG::factory_implementation {
+struct LinearGradientView : LinearGradientViewT<LinearGradientView, implementation::LinearGradientView> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/LinearGradientView.h
+++ b/windows/RNSVG/LinearGradientView.h
@@ -1,27 +1,28 @@
 #pragma once
 #include "LinearGradientView.g.h"
-#include "GroupView.h"
+#include "BrushView.h"
 
 namespace winrt::RNSVG::implementation {
-struct LinearGradientView : LinearGradientViewT<LinearGradientView, RNSVG::implementation::GroupView> {
+struct LinearGradientView : LinearGradientViewT<LinearGradientView, RNSVG::implementation::BrushView> {
  public:
   LinearGradientView() = default;
 
-  // IDefinitionView
-  void SaveDefinition();
-  void RemoveDefinition();
-
   // RenderableView
   void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
-  void Render(
-      Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
-      Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
 
  private:
   RNSVG::SVGLength m_x1{};
   RNSVG::SVGLength m_y1{};
   RNSVG::SVGLength m_x2{};
   RNSVG::SVGLength m_y2{};
+  std::vector<Microsoft::Graphics::Canvas::Brushes::CanvasGradientStop> m_stops{};
+  std::string m_gradientUnits{"objectBoundingBox"};
+  bool m_transformSet{false};
+  Numerics::float3x2 m_transform{Numerics::make_float3x2_scale(1)};
+
+  void CreateBrush();
+  void UpdateBounds();
+  void SetPoints(Microsoft::Graphics::Canvas::Brushes::CanvasLinearGradientBrush brush, Windows::Foundation::Rect const &bounds);
 };
 } // namespace winrt::RNSVG::implementation
 

--- a/windows/RNSVG/LinearGradientViewManager.cpp
+++ b/windows/RNSVG/LinearGradientViewManager.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+#include "LinearGradientViewManager.h"
+#include "LinearGradientViewManager.g.cpp"
+
+using namespace winrt;
+using namespace Microsoft::ReactNative;
+
+namespace winrt::RNSVG::implementation {
+LinearGradientViewManager::LinearGradientViewManager() {
+  m_class = RNSVG::SVGClass::RNSVGLinearGradient;
+  m_name = L"RNSVGLinearGradient";
+}
+
+IMapView<hstring, ViewManagerPropertyType> LinearGradientViewManager::NativeProps() {
+  auto const& parentProps{__super::NativeProps()};
+  auto const &nativeProps{winrt::single_threaded_map<hstring, ViewManagerPropertyType>()};
+
+  for (auto const &prop : parentProps) {
+    nativeProps.Insert(prop.Key(), prop.Value());
+  }
+
+  nativeProps.Insert(L"x1", ViewManagerPropertyType::String);
+  nativeProps.Insert(L"y1", ViewManagerPropertyType::String);
+  nativeProps.Insert(L"x2", ViewManagerPropertyType::String);
+  nativeProps.Insert(L"y2", ViewManagerPropertyType::String);
+  nativeProps.Insert(L"gradient", ViewManagerPropertyType::Array);
+  nativeProps.Insert(L"gradientUnits", ViewManagerPropertyType::Number);
+  nativeProps.Insert(L"gradientTransform", ViewManagerPropertyType::Array);
+
+  return nativeProps.GetView();
+}
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/LinearGradientViewManager.h
+++ b/windows/RNSVG/LinearGradientViewManager.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "LinearGradientViewManager.g.h"
+#include "GroupViewManager.h"
+
+namespace winrt::RNSVG::implementation {
+struct LinearGradientViewManager
+    : LinearGradientViewManagerT<LinearGradientViewManager, RNSVG::implementation::GroupViewManager> {
+  LinearGradientViewManager();
+
+  // IViewManagerWithNativeProperties
+  Windows::Foundation::Collections::IMapView<hstring, Microsoft::ReactNative::ViewManagerPropertyType> NativeProps();
+};
+} // namespace winrt::RNSVG::implementation
+
+namespace winrt::RNSVG::factory_implementation {
+struct LinearGradientViewManager
+    : LinearGradientViewManagerT<LinearGradientViewManager, implementation::LinearGradientViewManager> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/RNSVG.vcxproj
+++ b/windows/RNSVG/RNSVG.vcxproj
@@ -112,10 +112,14 @@
   <ItemGroup>
     <ClInclude Include="CircleView.h" />
     <ClInclude Include="CircleViewManager.h" />
+    <ClInclude Include="DefsView.h" />
+    <ClInclude Include="DefsViewManager.h" />
     <ClInclude Include="EllipseView.h" />
     <ClInclude Include="EllipseViewManager.h" />
     <ClInclude Include="GroupView.h" />
     <ClInclude Include="GroupViewManager.h" />
+    <ClInclude Include="LinearGradientView.h" />
+    <ClInclude Include="LinearGradientViewManager.h" />
     <ClInclude Include="LineView.h" />
     <ClInclude Include="LineViewManager.h" />
     <ClInclude Include="PathView.h" />
@@ -145,10 +149,14 @@
   <ItemGroup>
     <ClCompile Include="CircleView.cpp" />
     <ClCompile Include="CircleViewManager.cpp" />
+    <ClCompile Include="DefsView.cpp" />
+    <ClCompile Include="DefsViewManager.cpp" />
     <ClCompile Include="EllipseView.cpp" />
     <ClCompile Include="EllipseViewManager.cpp" />
     <ClCompile Include="GroupView.cpp" />
     <ClCompile Include="GroupViewManager.cpp" />
+    <ClCompile Include="LinearGradientView.cpp" />
+    <ClCompile Include="LinearGradientViewManager.cpp" />
     <ClCompile Include="LineView.cpp" />
     <ClCompile Include="LineViewManager.cpp" />
     <ClCompile Include="PathView.cpp" />

--- a/windows/RNSVG/RNSVG.vcxproj
+++ b/windows/RNSVG/RNSVG.vcxproj
@@ -110,6 +110,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="BrushView.h" />
     <ClInclude Include="CircleView.h" />
     <ClInclude Include="CircleViewManager.h" />
     <ClInclude Include="DefsView.h" />
@@ -147,6 +148,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="BrushView.cpp" />
     <ClCompile Include="CircleView.cpp" />
     <ClCompile Include="CircleViewManager.cpp" />
     <ClCompile Include="DefsView.cpp" />

--- a/windows/RNSVG/RNSVG.vcxproj.filters
+++ b/windows/RNSVG/RNSVG.vcxproj.filters
@@ -88,6 +88,18 @@
     <ClCompile Include="UseViewManager.cpp">
       <Filter>ViewManagers</Filter>
     </ClCompile>
+    <ClCompile Include="DefsViewManager.cpp">
+      <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClCompile>
+    <ClCompile Include="LinearGradientViewManager.cpp">
+      <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClCompile>
+    <ClCompile Include="DefsView.cpp">
+      <Filter>Views\GroupViews</Filter>
+    </ClCompile>
+    <ClCompile Include="LinearGradientView.cpp">
+      <Filter>Views\GroupViews</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -170,6 +182,18 @@
     </ClInclude>
     <ClInclude Include="UseViewManager.h">
       <Filter>ViewManagers</Filter>
+    </ClInclude>
+    <ClInclude Include="DefsViewManager.h">
+      <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClInclude>
+    <ClInclude Include="LinearGradientViewManager.h">
+      <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClInclude>
+    <ClInclude Include="DefsView.h">
+      <Filter>Views\GroupViews</Filter>
+    </ClInclude>
+    <ClInclude Include="LinearGradientView.h">
+      <Filter>Views\GroupViews</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/windows/RNSVG/RNSVG.vcxproj.filters
+++ b/windows/RNSVG/RNSVG.vcxproj.filters
@@ -100,6 +100,9 @@
     <ClCompile Include="LinearGradientView.cpp">
       <Filter>Views\GroupViews</Filter>
     </ClCompile>
+    <ClCompile Include="BrushView.cpp">
+      <Filter>Views</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -194,6 +197,9 @@
     </ClInclude>
     <ClInclude Include="LinearGradientView.h">
       <Filter>Views\GroupViews</Filter>
+    </ClInclude>
+    <ClInclude Include="BrushView.h">
+      <Filter>Views</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/windows/RNSVG/ReactPackageProvider.cpp
+++ b/windows/RNSVG/ReactPackageProvider.cpp
@@ -16,6 +16,8 @@
 #include "TextViewManager.h"
 #include "TSpanViewManager.h"
 #include "SymbolViewManager.h"
+#include "DefsViewManager.h"
+#include "LinearGradientViewManager.h"
 
 using namespace winrt::Microsoft::ReactNative;
 
@@ -35,6 +37,8 @@ namespace winrt::RNSVG::implementation
     packageBuilder.AddViewManager(L"TextViewManager", []() { return winrt::make<TextViewManager>(); });
     packageBuilder.AddViewManager(L"TSpanViewManager", []() { return winrt::make<TSpanViewManager>(); });
     packageBuilder.AddViewManager(L"SymbolViewManager", []() { return winrt::make<SymbolViewManager>(); });
+    packageBuilder.AddViewManager(L"DefsViewManager", []() { return winrt::make<DefsViewManager>(); });
+    packageBuilder.AddViewManager(L"LinearGradientViewManager", []() { return winrt::make<LinearGradientViewManager>(); });
   }
 
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -35,6 +35,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination FillRule() { return m_fillRule; }
 
   virtual void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate = true, bool invalidate = true);
+  virtual void SaveDefinition();
   virtual void CreateGeometry(Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &/*canvas*/) {}
   virtual void Render(
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,

--- a/windows/RNSVG/RenderableViewManager.cpp
+++ b/windows/RNSVG/RenderableViewManager.cpp
@@ -30,6 +30,10 @@ Windows::UI::Xaml::FrameworkElement RenderableViewManager::CreateView() {
       return winrt::RNSVG::TSpanView();
     case RNSVG::SVGClass::RNSVGSymbol:
       return winrt::RNSVG::SymbolView();
+    case RNSVG::SVGClass::RNSVGDefs:
+      return winrt::RNSVG::DefsView();
+    case RNSVG::SVGClass::RNSVGLinearGradient:
+      return winrt::RNSVG::LinearGradientView();
   }
 
   throw hresult_not_implemented();

--- a/windows/RNSVG/SvgView.cpp
+++ b/windows/RNSVG/SvgView.cpp
@@ -87,6 +87,12 @@ void SvgView::Canvas_Draw(UI::Xaml::CanvasControl const &sender, UI::Xaml::Canva
 
   for (auto const &child : Views()) {
     if (auto const &group{child.try_as<IRenderableView>()}) {
+      group.SaveDefinition();
+    }
+  }
+
+  for (auto const &child : Views()) {
+    if (auto const &group{child.try_as<IRenderableView>()}) {
       group.Render(sender, args.DrawingSession());
     }
   }

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -9,12 +9,16 @@ struct SvgView : SvgViewT<SvgView> {
 
   SvgView(Microsoft::ReactNative::IReactContext const &context);
 
+  Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl Canvas() { return m_canvas; }
   float SvgScale() { return m_scale; }
   Windows::Foundation::Collections::IVector<Windows::UI::Xaml::UIElement> Views() {
     return m_views;
   }
   Windows::Foundation::Collections::IMap<hstring, RNSVG::RenderableView> Templates() {
     return m_templates;
+  }
+  Windows::Foundation::Collections::IMap<hstring, RNSVG::BrushView> Brushes() {
+    return m_brushes;
   }
 
   void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader);
@@ -53,6 +57,8 @@ struct SvgView : SvgViewT<SvgView> {
       winrt::single_threaded_vector<Windows::UI::Xaml::UIElement>()};
   Windows::Foundation::Collections::IMap<hstring, RNSVG::RenderableView> m_templates{
       winrt::single_threaded_map<hstring, RNSVG::RenderableView>()};
+  Windows::Foundation::Collections::IMap<hstring, RNSVG::BrushView> m_brushes{
+      winrt::single_threaded_map<hstring, RNSVG::BrushView>()};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl::Draw_revoker m_canvasDrawRevoker{};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl::SizeChanged_revoker m_canvaSizeChangedRevoker{};
 };

--- a/windows/RNSVG/SymbolView.cpp
+++ b/windows/RNSVG/SymbolView.cpp
@@ -9,19 +9,6 @@ using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::ReactNative;
 
 namespace winrt::RNSVG::implementation {
-void SymbolView::SaveDefinition() {
-  if (auto const &root{SvgRoot()}) {
-    root.Templates().Insert(Id(), *this);
-  }
-}
-
-void SymbolView::RemoveDefinition() {
-  const auto &root{SvgRoot()};
-  if (root && root.Templates().HasKey(Id())) {
-    root.Templates().Remove(Id());
-  }
-}
-
 void SymbolView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
   const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
 
@@ -29,9 +16,7 @@ void SymbolView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate
     auto const &propertyName{pair.first};
     auto const &propertyValue{pair.second};
 
-    if (propertyName == "name") {
-      RemoveDefinition();
-    } else if (propertyName == "vbWidth") {
+    if (propertyName == "vbWidth") {
       m_vbWidth = Utils::JSValueAsFloat(propertyValue);
     } else if (propertyName == "vbHeight") {
       m_vbHeight = Utils::JSValueAsFloat(propertyValue);
@@ -47,14 +32,6 @@ void SymbolView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate
   }
 
   __super::UpdateProperties(reader, forceUpdate, invalidate);
-
-  if (propertyMap.find("name") != propertyMap.end()) {
-    SaveDefinition();
-  }
-}
-
-void SymbolView::Render(UI::Xaml::CanvasControl const &/*canvas*/, CanvasDrawingSession const &/*session*/) {
-  SaveDefinition();
 }
 
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/SymbolView.h
+++ b/windows/RNSVG/SymbolView.h
@@ -14,13 +14,11 @@ struct SymbolView : SymbolViewT<SymbolView, RNSVG::implementation::GroupView> {
   hstring Align() { return to_hstring(m_align); }
   RNSVG::MeetOrSlice MeetOrSlice() { return m_meetOrSlice; }
 
-  void SaveDefinition();
-  void RemoveDefinition();
-
+  // RenderableView
   void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
   void Render(
-      Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
-      Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
+      Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &/*canvas*/,
+      Microsoft::Graphics::Canvas::CanvasDrawingSession const &/*session*/){};
 
  private:
   float m_minX{0.0f};

--- a/windows/RNSVG/ViewManagers.idl
+++ b/windows/RNSVG/ViewManagers.idl
@@ -89,6 +89,18 @@ namespace RNSVG
   }
 
   [default_interface]
+  runtimeclass DefsViewManager : GroupViewManager
+  {
+    DefsViewManager();
+  }
+
+  [default_interface]
+  runtimeclass LinearGradientViewManager : GroupViewManager
+  {
+    LinearGradientViewManager();
+  }
+
+  [default_interface]
   runtimeclass SymbolViewManager : GroupViewManager
   {
     SymbolViewManager();

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -176,6 +176,18 @@ namespace RNSVG
   };
 
   [default_interface]
+  runtimeclass DefsView : GroupView
+  {
+    DefsView();
+  };
+
+  [default_interface]
+  runtimeclass LinearGradientView : GroupView, IDefinitionView
+  {
+    LinearGradientView();
+  };
+
+  [default_interface]
   runtimeclass SymbolView : GroupView, IDefinitionView
   {
     SymbolView();

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -34,9 +34,13 @@ namespace RNSVG
   runtimeclass SvgView : Windows.UI.Xaml.Controls.Panel
   {
     SvgView(Microsoft.ReactNative.IReactContext context);
+
     Single SvgScale{ get; };
-    Windows.Foundation.Collections.IVector<Windows.UI.Xaml.UIElement> Views { get; };
+    Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl Canvas{ get; };
+    Windows.Foundation.Collections.IVector<Windows.UI.Xaml.UIElement> Views{ get; };
     Windows.Foundation.Collections.IMap<String, RenderableView> Templates{ get; };
+    Windows.Foundation.Collections.IMap<String, BrushView> Brushes{ get; };
+
     void UpdateProperties(Microsoft.ReactNative.IJSValueReader reader);
     void InvalidateCanvas();
   };
@@ -66,12 +70,6 @@ namespace RNSVG
     Unknown,
   };
 
-  interface IDefinitionView
-  {
-    void SaveDefinition();
-    void RemoveDefinition();
-  };
-
   [default_interface]
   unsealed runtimeclass RenderableView : Windows.UI.Xaml.FrameworkElement
   {
@@ -98,6 +96,7 @@ namespace RNSVG
 
     void UpdateProperties(Microsoft.ReactNative.IJSValueReader reader, Boolean forceUpdate, Boolean invalidate);
 
+    void SaveDefinition();
     void CreateGeometry(Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas);
     void Render(
       Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas,
@@ -182,13 +181,7 @@ namespace RNSVG
   };
 
   [default_interface]
-  runtimeclass LinearGradientView : GroupView, IDefinitionView
-  {
-    LinearGradientView();
-  };
-
-  [default_interface]
-  runtimeclass SymbolView : GroupView, IDefinitionView
+  runtimeclass SymbolView : GroupView
   {
     SymbolView();
     Single MinX{ get; };
@@ -197,5 +190,21 @@ namespace RNSVG
     Single VbHeight{ get; };
     String Align{ get; };
     MeetOrSlice MeetOrSlice{ get; };
+  };
+
+  [default_interface]
+  unsealed runtimeclass BrushView : GroupView
+  {
+    BrushView();
+
+    Microsoft.Graphics.Canvas.Brushes.ICanvasBrush Brush{ get; };
+    void CreateBrush();
+    void SetBounds(Windows.Foundation.Rect rect);
+  };
+
+  [default_interface]
+  runtimeclass LinearGradientView : BrushView
+  {
+    LinearGradientView();
   };
   }


### PR DESCRIPTION
- The entire purpose of Defs is to override the Render method and no-op.
- Deleted IDefinitionView and moved SaveDefinition() to RenderableView.
- Before Render, we now cycle though the tree to save all definitions. 
- Added BrushView:
- - To be used by LinearGradient, RadialGradient, and Pattern.
- - Overrides SaveDefinition to save to SvgRoot().Brushes instead of SvgRoot().Templates().
- Implemented LinearGradient. 