### PR TITLE
Fix prop inheritance of reusable elements and CanvasControl memory leak.

### DIFF
--- a/example/examples/Reusable.js
+++ b/example/examples/Reusable.js
@@ -2,11 +2,89 @@
 import React from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
-import {Svg, Use, Symbol, Circle} from 'react-native-svg';
+import {Svg, Defs, G, Use, Symbol, Circle, Rect, Path, LinearGradient, Stop} from 'react-native-svg';
 
 export const ReusablePage: React.FunctionComponent<{}> = () => {
   return (
     <Page title="Reusable">
+      <Example title="Reuse svg code">
+        <Svg height="100" width="300">
+          <Defs>
+            <G id="reuse-shape" fill="black">
+              <Circle cx="50" cy="50" r="50" />
+              <Rect x="50" y="50" width="50" height="50" />
+              <Circle cx="50" cy="50" r="5" fill="blue" />
+            </G>
+          </Defs>
+          <Use href="#reuse-shape" x="20" y="0" />
+          <Use href="#reuse-shape" x="170" y="0" />
+        </Svg>
+      </Example>
+      <Example title="Using Shapes Outside of a Defs Element">
+        <Svg height="110" width="200">
+          <G id="outside-shape">
+            <Rect x="0" y="0" width="50" height="50" />
+          </G>
+          <Use href="#outside-shape" x="75" y="50" fill="#0f0" />
+          <Use
+            href="#outside-shape"
+            x="110"
+            y="0"
+            stroke="#0ff"
+            fill="#8a3"
+            rotation="45"
+          />
+          <Use
+            href="#outside-shape"
+            x="150"
+            y="50"
+            stroke="#0f0"
+            strokeWidth="1"
+            fill="none"
+          />
+        </Svg>
+      </Example>
+      <Example title="Basic Defs usage">
+        <Svg height="100" width="100">
+          <Defs>
+            <G id="basic-path" x="5" y="2" opacity="0.9">
+              <Path
+                id="basic-test"
+                d="M38.459,1.66A0.884,0.884,0,0,1,39,2.5a0.7,0.7,0,0,1-.3.575L23.235,16.092,27.58,26.1a1.4,1.4,0,0,1,.148.3,1.3,1.3,0,0,1,0,.377,1.266,1.266,0,0,1-2.078.991L15.526,20.6l-7.58,4.35a1.255,1.255,0,0,1-.485,0,1.267,1.267,0,0,1-1.277-1.258q0-.01,0-0.02a1.429,1.429,0,0,1,0-.446C7.243,20.253,8.6,16.369,8.6,16.29L3.433,13.545A0.743,0.743,0,0,1,2.9,12.822a0.822,0.822,0,0,1,.623-0.773l8.164-2.972,3.018-8.5A0.822,0.822,0,0,1,15.427,0a0.752,0.752,0,0,1,.752.555l2.563,6.936S37.65,1.727,37.792,1.685A1.15,1.15,0,0,1,38.459,1.66Z"
+              />
+            </G>
+            {/* <ClipPath id="basic-clip">
+              <Circle r="25%" cx="0%" cy="0%" />
+            </ClipPath> */}
+            <LinearGradient id="basic-linear" x1="0%" y1="0%" x2="100%" y2="0%">
+              <Stop offset="0%" stopColor="yellow" />
+              <Stop offset="50%" stopColor="red" />
+              <Stop offset="100%" stopColor="blue" />
+            </LinearGradient>
+            {/* <RadialGradient
+              id="basic-radial"
+              cx="50%"
+              cy="50%"
+              r="50%"
+              fx="50%"
+              fy="50%">
+              <Stop offset="0%" stopColor="yellow" />
+              <Stop offset="50%" stopColor="red" />
+              <Stop offset="100%" stopColor="blue" />
+            </RadialGradient> */}
+          </Defs>
+          <Use href="#basic-path" x="0" fill="blue" opacity="0.6" />
+          <Use href="#basic-path" x="20" y="5" fill="url(#basic-linear)" />
+          {/* <Use
+            href="#basic-path"
+            clipPath="url(#basic-clip)"
+            fillOpacity="0.6"
+            stroke="#000"
+            strokeWidth="1"
+          />
+          <Use href="#basic-path" x="-10" y="20" fill="url(#basic-radial)" /> */}
+        </Svg>
+      </Example>
       <Example title="Symbol example, reuse elements with viewBox prop">
         <Svg height="150" width="110">
           <Symbol id="example-symbol" viewBox="0 0 150 110">

--- a/windows/RNSVG/BrushView.cpp
+++ b/windows/RNSVG/BrushView.cpp
@@ -14,4 +14,10 @@ void BrushView::SetBounds(Windows::Foundation::Rect const &rect) {
   m_bounds = rect;
   UpdateBounds();
 }
+
+void BrushView::Unload() {
+  m_brush = nullptr;
+
+  __super::Unload();
+}
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/BrushView.h
+++ b/windows/RNSVG/BrushView.h
@@ -11,7 +11,9 @@ struct BrushView : BrushViewT<BrushView, RNSVG::implementation::GroupView> {
 
   Microsoft::Graphics::Canvas::Brushes::ICanvasBrush Brush() { return m_brush; }
   virtual void CreateBrush() {}
+  virtual void Unload();
   void SetBounds(Windows::Foundation::Rect const &rect);
+
 
  protected:
   Microsoft::Graphics::Canvas::Brushes::ICanvasBrush m_brush{nullptr};

--- a/windows/RNSVG/GroupView.cpp
+++ b/windows/RNSVG/GroupView.cpp
@@ -133,12 +133,28 @@ void GroupView::SaveDefinition() {
   }
 }
 
+void GroupView::MergeProperties(RNSVG::RenderableView const &other) {
+  __super::MergeProperties(other);
+
+  for (auto const &child : Children()) {
+    child.MergeProperties(*this);
+  }
+}
+
 void GroupView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSession const &session) {
+  auto const &transform{session.Transform()};
+
+  if (m_propSetMap[RNSVG::BaseProp::Matrix]) {
+    session.Transform(transform * SvgTransform());
+  }
+
   if (Children().Size() == 0) {
     __super::Render(canvas, session);
   } else {
     RenderGroup(canvas, session);
   }
+
+  session.Transform(transform);
 }
 
 void GroupView::RenderGroup(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSession const &session) {

--- a/windows/RNSVG/GroupView.cpp
+++ b/windows/RNSVG/GroupView.cpp
@@ -162,4 +162,17 @@ void GroupView::RenderGroup(UI::Xaml::CanvasControl const &canvas, CanvasDrawing
     child.Render(canvas, session);
   }
 }
+
+void GroupView::Unload() {
+  for (auto const &child : Children()) {
+    child.Unload();
+  }
+
+  m_reactContext = nullptr;
+  m_props = nullptr;
+  m_fontPropMap.clear();
+  m_children.Clear();
+
+  __super::Unload();
+}
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/GroupView.h
+++ b/windows/RNSVG/GroupView.h
@@ -35,6 +35,8 @@ struct GroupView : GroupViewT<GroupView, RNSVG::implementation::RenderableView> 
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
       Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
 
+  virtual void Unload();
+
  private:
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
   Windows::Foundation::Collections::IVector<RNSVG::RenderableView> m_children{

--- a/windows/RNSVG/GroupView.h
+++ b/windows/RNSVG/GroupView.h
@@ -25,6 +25,8 @@ struct GroupView : GroupViewT<GroupView, RNSVG::implementation::RenderableView> 
 
   virtual void SaveDefinition();
 
+  virtual void MergeProperties(RNSVG::RenderableView const &other);
+
   virtual void Render(
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
       Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);

--- a/windows/RNSVG/LinearGradientView.cpp
+++ b/windows/RNSVG/LinearGradientView.cpp
@@ -54,6 +54,11 @@ void LinearGradientView::UpdateProperties(IJSValueReader const &reader, bool for
   SaveDefinition();
 }
 
+void LinearGradientView::Unload() {
+  m_stops.clear();
+  __super::Unload();
+}
+
 void LinearGradientView::CreateBrush() {
   auto const &canvas{SvgRoot().Canvas()};
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};

--- a/windows/RNSVG/LinearGradientView.h
+++ b/windows/RNSVG/LinearGradientView.h
@@ -9,6 +9,7 @@ struct LinearGradientView : LinearGradientViewT<LinearGradientView, RNSVG::imple
 
   // RenderableView
   void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
+  void Unload();
 
  private:
   RNSVG::SVGLength m_x1{};

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -13,7 +13,7 @@ using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::ReactNative;
 
 namespace winrt::RNSVG::implementation {
-void RenderableView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate){
+void RenderableView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
   const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
   auto const &parent{SvgParent().try_as<RNSVG::RenderableView>()};
 
@@ -36,7 +36,7 @@ void RenderableView::UpdateProperties(IJSValueReader const &reader, bool forceUp
     } else if (propertyName == "strokeWidth") {
       prop = RNSVG::BaseProp::StrokeWidth;
       if (forceUpdate || !m_propSetMap[prop]) {
-        auto const &fallbackValue{parent ? parent.StrokeWidth() : RNSVG::SVGLength()};
+        auto const &fallbackValue{parent ? parent.StrokeWidth() : RNSVG::SVGLength(1.0f, RNSVG::UnitType::PX)};
         m_strokeWidth = Utils::JSValueAsSVGLength(propertyValue, fallbackValue);
       }
     } else if (propertyName == "strokeOpacity") {
@@ -164,10 +164,12 @@ void RenderableView::UpdateProperties(IJSValueReader const &reader, bool forceUp
       }
     } else if (propertyName == "matrix") {
       prop = RNSVG::BaseProp::Matrix;
-      if (forceUpdate || !m_propSetMap[prop]) {
+      if (forceUpdate) {
         Numerics::float3x2 fallbackValue{parent ? parent.SvgTransform() : Numerics::make_float3x2_rotation(0)};
         m_transformMatrix = Utils::JSValueAsTransform(propertyValue, fallbackValue);
       }
+    } else if (propertyName == "opacity") {
+      m_opacity = Utils::JSValueAsFloat(propertyValue);
     }
 
     // forceUpdate = true means the property is being set on an element
@@ -201,7 +203,10 @@ void RenderableView::Render(
   }
 
   auto geometry{Geometry()};
-  geometry = geometry.Transform(SvgTransform());
+  if (m_propSetMap[RNSVG::BaseProp::Matrix]) {
+    geometry = geometry.Transform(SvgTransform());
+  }
+
   geometry = Geometry::CanvasGeometry::CreateGroup(resourceCreator, {geometry}, FillRule());
 
   if (auto const &fillLayer{session.CreateLayer(FillOpacity())}) {
@@ -222,6 +227,53 @@ void RenderableView::Render(
     auto const &stroke{Utils::GetCanvasBrush(StrokeBrushId(), Stroke(), SvgRoot(), geometry, resourceCreator)};
     session.DrawGeometry(geometry, stroke, StrokeWidth().Value(), strokeStyle);
     strokeLayer.Close();
+  }
+}
+
+void RenderableView::MergeProperties(RNSVG::RenderableView const &other) {
+  for (auto const &prop : m_propSetMap) {
+    if (!prop.second) {
+      switch (prop.first) {
+        case RNSVG::BaseProp::Fill:
+          m_fill = other.Fill();
+          m_fillBrushId = other.FillBrushId();
+          break;
+        case RNSVG::BaseProp::FillOpacity:
+          m_fillOpacity = other.FillOpacity();
+          break;
+        case RNSVG::BaseProp::FillRule:
+          m_fillRule = other.FillRule();
+          break;
+        case RNSVG::BaseProp::Stroke:
+          m_stroke = other.Stroke();
+          m_strokeBrushId = other.StrokeBrushId();
+          break;
+        case RNSVG::BaseProp::StrokeOpacity:
+          m_strokeOpacity = other.StrokeOpacity();
+          break;
+        case RNSVG::BaseProp::StrokeWidth:
+          m_strokeWidth = other.StrokeWidth();
+          break;
+        case RNSVG::BaseProp::StrokeMiterLimit:
+          m_strokeMiterLimit = other.StrokeMiterLimit();
+          break;
+        case RNSVG::BaseProp::StrokeDashOffset:
+          m_strokeDashOffset = other.StrokeDashOffset();
+          break;
+        case RNSVG::BaseProp::StrokeDashArray:
+          m_strokeDashArray = other.StrokeDashArray();
+          break;
+        case RNSVG::BaseProp::StrokeLineCap:
+          m_strokeLineCap = other.StrokeLineCap();
+          break;
+        case RNSVG::BaseProp::StrokeLineJoin:
+          m_strokeLineJoin = other.StrokeLineJoin();
+          break;
+        case RNSVG::BaseProp::Unknown:
+        default:
+          break;
+      }
+    }
   }
 }
 

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -288,4 +288,12 @@ RNSVG::SvgView RenderableView::SvgRoot() {
 
   return {nullptr};
 }
+
+void RenderableView::Unload() {
+  m_parent = nullptr;
+  m_reactContext = nullptr;
+  m_geometry = nullptr;
+  m_propSetMap.clear();
+  m_strokeDashArray.Clear();
+}
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -34,12 +34,30 @@ struct RenderableView : RenderableViewT<RenderableView> {
   Microsoft::Graphics::Canvas::Geometry::CanvasLineJoin StrokeLineJoin() { return m_strokeLineJoin; }
   Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination FillRule() { return m_fillRule; }
 
+  virtual void MergeProperties(RNSVG::RenderableView const &other);
   virtual void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate = true, bool invalidate = true);
   virtual void SaveDefinition();
   virtual void CreateGeometry(Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &/*canvas*/) {}
   virtual void Render(
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
       Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
+
+ protected:
+  std::map<RNSVG::BaseProp, bool> m_propSetMap{
+      {RNSVG::BaseProp::Matrix, false},
+      {RNSVG::BaseProp::Fill, false},
+      {RNSVG::BaseProp::FillOpacity, false},
+      {RNSVG::BaseProp::FillRule, false},
+      {RNSVG::BaseProp::Stroke, false},
+      {RNSVG::BaseProp::StrokeOpacity, false},
+      {RNSVG::BaseProp::StrokeWidth, false},
+      {RNSVG::BaseProp::StrokeMiterLimit, false},
+      {RNSVG::BaseProp::StrokeDashOffset, false},
+      {RNSVG::BaseProp::StrokeDashArray, false},
+      {RNSVG::BaseProp::StrokeLineCap, false},
+      {RNSVG::BaseProp::StrokeLineJoin, false},
+  };
+  float m_opacity{1.0f};
 
  private:
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
@@ -57,7 +75,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   float m_strokeOpacity{1.0f};
   float m_strokeMiterLimit{0.0f};
   float m_strokeDashOffset{0.0f};
-  RNSVG::SVGLength m_strokeWidth{};
+  RNSVG::SVGLength m_strokeWidth{1.0f, RNSVG::UnitType::PX};
   Windows::Foundation::Collections::IVector<RNSVG::SVGLength> m_strokeDashArray{
       winrt::single_threaded_vector<RNSVG::SVGLength>()};
   Microsoft::Graphics::Canvas::Geometry::CanvasCapStyle m_strokeLineCap{
@@ -66,21 +84,6 @@ struct RenderableView : RenderableViewT<RenderableView> {
       Microsoft::Graphics::Canvas::Geometry::CanvasLineJoin::Miter};
   Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination m_fillRule{
       Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination::Winding};
-
-  std::map<RNSVG::BaseProp, bool> m_propSetMap{
-      {RNSVG::BaseProp::Matrix, false},
-      {RNSVG::BaseProp::Fill, false},
-      {RNSVG::BaseProp::FillOpacity, false},
-      {RNSVG::BaseProp::FillRule, false},
-      {RNSVG::BaseProp::Stroke, false},
-      {RNSVG::BaseProp::StrokeOpacity, false},
-      {RNSVG::BaseProp::StrokeWidth, false},
-      {RNSVG::BaseProp::StrokeMiterLimit, false},
-      {RNSVG::BaseProp::StrokeDashOffset, false},
-      {RNSVG::BaseProp::StrokeDashArray, false},
-      {RNSVG::BaseProp::StrokeLineCap, false},
-      {RNSVG::BaseProp::StrokeLineJoin, false},
-  };
 };
 } // namespace winrt::RNSVG::implementation
 

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -41,6 +41,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   virtual void Render(
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas,
       Microsoft::Graphics::Canvas::CanvasDrawingSession const &session);
+  virtual void Unload();
 
  protected:
   std::map<RNSVG::BaseProp, bool> m_propSetMap{

--- a/windows/RNSVG/RenderableViewManager.cpp
+++ b/windows/RNSVG/RenderableViewManager.cpp
@@ -56,6 +56,7 @@ IMapView<hstring, ViewManagerPropertyType> RenderableViewManager::NativeProps() 
   nativeProps.Insert(L"strokeDashoffset", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"strokeDasharray", ViewManagerPropertyType::Array);
   nativeProps.Insert(L"matrix", ViewManagerPropertyType::Array);
+  nativeProps.Insert(L"opacity", ViewManagerPropertyType::Number);
 
   return nativeProps.GetView();
 }

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -36,6 +36,8 @@ struct SvgView : SvgViewT<SvgView> {
       Windows::Foundation::IInspectable const &sender,
       Windows::UI::Xaml::SizeChangedEventArgs const &args);
 
+  void Panel_Unloaded(Windows::Foundation::IInspectable const &sender, Windows::UI::Xaml::RoutedEventArgs const &args);
+
   void InvalidateCanvas();
 
  private:
@@ -61,6 +63,7 @@ struct SvgView : SvgViewT<SvgView> {
       winrt::single_threaded_map<hstring, RNSVG::BrushView>()};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl::Draw_revoker m_canvasDrawRevoker{};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl::SizeChanged_revoker m_canvaSizeChangedRevoker{};
+  Windows::UI::Xaml::FrameworkElement::Unloaded_revoker m_panelUnloadedRevoker{};
 };
 } // namespace winrt::RNSVG::implementation
 

--- a/windows/RNSVG/UseView.cpp
+++ b/windows/RNSVG/UseView.cpp
@@ -38,8 +38,11 @@ void UseView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, b
 
 void UseView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSession const &session) {
   if (auto const &view{GetRenderableTemplate()}) {
+    auto const &originalTransform{session.Transform()};
+    auto transform{Numerics::make_float3x2_scale(1)};
+
+    // Figure out any necessary transforms
     if (auto const &symbol{view.try_as<RNSVG::SymbolView>()}) {
-      auto const &transform{session.Transform()};
       if (symbol.Align() != L"") {
         if (auto const &root{SvgRoot()}) {
           Rect vbRect{
@@ -54,38 +57,43 @@ void UseView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSession
           float elHeight{Utils::GetSvgLengthValue(m_height, canvas.Size().Height)};
           Rect elRect{elX, elY, elWidth, elHeight};
 
-          session.Transform(Utils::GetViewBoxTransform(vbRect, elRect, to_string(symbol.Align()), symbol.MeetOrSlice()));
+          transform = Utils::GetViewBoxTransform(vbRect, elRect, to_string(symbol.Align()), symbol.MeetOrSlice());
         }
       }
-
-      symbol.RenderGroup(canvas, session);
-      session.Transform(transform);
     } else {
-      auto const &originalTransform{session.Transform()};
-
       float x{Utils::GetSvgLengthValue(m_x, canvas.Size().Width)};
       float y{Utils::GetSvgLengthValue(m_y, canvas.Size().Height)};
-      Numerics::float3x2 transform{Numerics::make_float3x2_translation({x, y})};
-
-      if (m_propSetMap[RNSVG::BaseProp::Matrix]) {
-        transform = transform * SvgTransform();
-      }
-
-      session.Transform(transform);
-
-      view.MergeProperties(*this);
-
-      if (auto const &opacityLayer{session.CreateLayer(m_opacity)}) {
-        view.Render(canvas, session);
-        opacityLayer.Close();
-      }
-
-      if (auto const &parent{view.SvgParent().try_as<RNSVG::RenderableView>()}) {
-        view.MergeProperties(parent);
-      }
-
-      session.Transform(originalTransform);
+      transform = Numerics::make_float3x2_translation({x, y});
     }
+
+    // Combine new transform with existing one if it's set
+    if (m_propSetMap[RNSVG::BaseProp::Matrix]) {
+      transform = transform * SvgTransform();
+    }
+
+    session.Transform(transform);
+
+    // Propagate props to template
+    view.MergeProperties(*this);
+
+    // Set opacity and render
+    if (auto const &opacityLayer{session.CreateLayer(m_opacity)}) {
+      if (auto const &symbol{view.try_as<RNSVG::SymbolView>()}) {
+        symbol.RenderGroup(canvas, session);
+      } else {
+        view.Render(canvas, session);
+      }
+      opacityLayer.Close();
+    }
+
+    // Restore original template props
+    if (auto const &parent{view.SvgParent().try_as<RNSVG::RenderableView>()}) {
+      view.MergeProperties(parent);
+    }
+
+    // Restore session transform
+    session.Transform(originalTransform);
+
   } else {
     throw hresult_not_implemented(L"'Use' element expected a pre-defined svg template as 'href' prop. Template named: " + m_href + L" is not defined");
   }

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -47,6 +47,7 @@ namespace RNSVG
 
   enum BaseProp
   {
+    Matrix,
     Fill,
     FillOpacity,
     FillRule,
@@ -101,6 +102,7 @@ namespace RNSVG
       Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas,
       Microsoft.Graphics.Canvas.CanvasDrawingSession session);
     void MergeProperties(RenderableView other);
+    void Unload();
   };
 
   [default_interface]

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -47,7 +47,6 @@ namespace RNSVG
 
   enum BaseProp
   {
-    Matrix,
     Fill,
     FillOpacity,
     FillRule,
@@ -101,6 +100,7 @@ namespace RNSVG
     void Render(
       Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas,
       Microsoft.Graphics.Canvas.CanvasDrawingSession session);
+    void MergeProperties(RenderableView other);
   };
 
   [default_interface]


### PR DESCRIPTION
- Prop propagation in reusable elements:
  - Use now pushes its props to its children (as long as the prop is not set on the child).
  - It then restores the child's original props after render. 
- CanvasControl memory leak:
  - https://microsoft.github.io/Win2D/WinUI2/html/RefCycles.htm
  - Have to listen to the Panel's Unloaded event and explicitly remove the canvas from the VisualTree in order for resources to be freed. 
