### PR TITLE
Stroke width fix for dashes & stroking example page

### DIFF
--- a/example/SVGExampleList.js
+++ b/example/SVGExampleList.js
@@ -11,6 +11,7 @@ import {PolygonPage} from './examples/Polygon';
 import {PolylinePage} from './examples/Polyline';
 import {ReusablePage} from './examples/Reusable';
 import {GradientsPage} from './examples/Gradients';
+import {StrokingPage} from './examples/Stroking';
 
 interface ISVGExample {
   key: string;
@@ -61,6 +62,10 @@ export const SVGExampleList: Array<ISVGExample> = [
   {
     key: 'Gradients',
     component: GradientsPage,
+  },
+  {
+    key: 'Stroking',
+    component: StrokingPage,
   },
 ];
 

--- a/example/examples/Stroking.js
+++ b/example/examples/Stroking.js
@@ -1,0 +1,105 @@
+'use strict';
+import React from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import {Svg, G, Path, Circle, Defs, Rect, Polyline} from 'react-native-svg';
+
+export const StrokingPage: React.FunctionComponent<{}> = () => {
+  return (
+    <Page title="Stroking">
+      <Example title="The stroke property defines the color of a line, text or outline of an element">
+        <Svg height="80" width="225">
+            <G strokeWidth="1">
+            <Path stroke="red" d="M5 20 l215 0" />
+            <Path stroke="black" d="M5 40 l215 0" />
+            <Path stroke="blue" d="M5 60 l215 0" />
+            </G>
+        </Svg>
+      </Example>
+      <Example title="The strokeLinecap property defines different types of endings to an open path">
+        <Svg height="80" width="225">
+            <G stroke="red" strokeWidth="8">
+            <Path strokeLinecap="butt" d="M5 20 l215 0" />
+            <Path strokeLinecap="round" d="M5 40 l215 0" />
+            <Path strokeLinecap="square" d="M5 60 l215 0" />
+            </G>
+        </Svg>
+      </Example>
+      <Example title="strokeDasharray">
+        <Svg height="80" width="225">
+            <G fill="none" stroke="black" strokeWidth="4">
+            <Path strokeDasharray="5,5" d="M5 20 l215 0" />
+            <Path strokeDasharray="10,10" d="M5 40 l215 0" />
+            <Path strokeDasharray="20,10,5,5,5,10" d="M5 60 l215 0" />
+            </G>
+        </Svg>
+      </Example>
+      <Example title="the strokeDashoffset attribute specifies the distance into the dash pattern to start the dash.">
+        <Svg height="80" width="200">
+            <Circle
+            cx="100"
+            cy="40"
+            r="35"
+            strokeWidth="5"
+            stroke="red"
+            fill="none"
+            strokeDasharray="100"
+            strokeDashoffset="0"
+            />
+            {/* <Text
+                stroke="blue"
+                strokeWidth="1"
+                fill="none"
+                fontSize="20"
+                fontWeight="bold"
+                x="100"
+                y="40"
+                textAnchor="middle"
+                strokeDasharray="100"
+                strokeDashoffset="60">
+                STROKE
+            </Text> */}
+        </Svg>
+      </Example>
+      <Example title="Advanced stroke example.">
+        <Svg height="80" width="200">
+            <Defs>
+            {/* <RadialGradient
+                id="advanced-stroke-grad"
+                cx="50%"
+                cy="50%"
+                rx="80%"
+                ry="80%"
+                fx="50%"
+                fy="50%">
+                <Stop offset="50%" stopColor="#fff" stopOpacity="0.5" />
+                <Stop offset="100%" stopColor="#f00" stopOpacity="1" />
+            </RadialGradient>
+             <ClipPath id="advanced-stroke-clip">
+                <Circle r="96" cx="100" cy="40" />
+            </ClipPath> */}
+            </Defs>
+            <Rect
+                x="5"
+                y="5"
+                height="70"
+                width="190"
+                fill="blue"
+                stroke="url(#advanced-stroke-grad)"
+                strokeWidth="5"
+                strokeDasharray="10"
+                clipPath="url(#advanced-stroke-clip)"
+            />
+            <Polyline
+                strokeDasharray="20,10,5,5,5,10"
+                points="10,10 20,12 30,20 40,60 60,70 90,55"
+                fill="none"
+                stroke="url(#advanced-stroke-grad)"
+                strokeLinecap="round"
+                strokeWidth="5"
+            />
+        </Svg>
+      </Example>
+    </Page>
+  );
+};

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -222,7 +222,8 @@ void RenderableView::Render(
     strokeStyle.LineJoin(StrokeLineJoin());
     strokeStyle.DashOffset(StrokeDashOffset());
     strokeStyle.MiterLimit(StrokeMiterLimit());
-    strokeStyle.CustomDashStyle(Utils::GetAdjustedStrokeArray(StrokeDashArray(), StrokeWidth()));
+    float strokeWidth{Utils::GetSvgLengthValue(StrokeWidth(), canvas.Size().Width)};
+    strokeStyle.CustomDashStyle(Utils::GetAdjustedStrokeArray(StrokeDashArray(), strokeWidth));
 
     auto const &stroke{Utils::GetCanvasBrush(StrokeBrushId(), Stroke(), SvgRoot(), geometry, resourceCreator)};
     session.DrawGeometry(geometry, stroke, StrokeWidth().Value(), strokeStyle);

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -222,7 +222,7 @@ void RenderableView::Render(
     strokeStyle.LineJoin(StrokeLineJoin());
     strokeStyle.DashOffset(StrokeDashOffset());
     strokeStyle.MiterLimit(StrokeMiterLimit());
-    strokeStyle.CustomDashStyle(Utils::GetValueArray(StrokeDashArray()));
+    strokeStyle.CustomDashStyle(Utils::GetAdjustedStrokeArray(StrokeDashArray(), StrokeWidth()));
 
     auto const &stroke{Utils::GetCanvasBrush(StrokeBrushId(), Stroke(), SvgRoot(), geometry, resourceCreator)};
     session.DrawGeometry(geometry, stroke, StrokeWidth().Value(), strokeStyle);

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -226,7 +226,7 @@ void RenderableView::Render(
     strokeStyle.CustomDashStyle(Utils::GetAdjustedStrokeArray(StrokeDashArray(), strokeWidth));
 
     auto const &stroke{Utils::GetCanvasBrush(StrokeBrushId(), Stroke(), SvgRoot(), geometry, resourceCreator)};
-    session.DrawGeometry(geometry, stroke, StrokeWidth().Value(), strokeStyle);
+    session.DrawGeometry(geometry, stroke, strokeWidth, strokeStyle);
     strokeLayer.Close();
   }
 }

--- a/windows/RNSVG/Utils.h
+++ b/windows/RNSVG/Utils.h
@@ -19,7 +19,7 @@ using namespace Windows::UI::Text;
 namespace winrt::RNSVG {
 struct Utils {
  public:
-  static std::vector<float> GetAdjustedStrokeArray(IVector<SVGLength> const &value, float StrokeWidth) {
+  static std::vector<float> GetAdjustedStrokeArray(IVector<SVGLength> const &value, float strokeWidth) {
     std::vector<float> result;
 
     for (auto const &item : value) {
@@ -27,7 +27,7 @@ struct Utils {
       * we divide each value in the dashArray by StrokeWidth to account for this. 
       http://microsoft.github.io/Win2D/WinUI2/html/P_Microsoft_Graphics_Canvas_Geometry_CanvasStrokeStyle_CustomDashStyle.htm
       */
-      result.push_back(item.Value() / StrokeWidth);
+      result.push_back(item.Value() / strokeWidth == 0.0f ? 1.0f : strokeWidth);
     }
 
     return std::move(result);

--- a/windows/RNSVG/Utils.h
+++ b/windows/RNSVG/Utils.h
@@ -19,11 +19,15 @@ using namespace Windows::UI::Text;
 namespace winrt::RNSVG {
 struct Utils {
  public:
-  static std::vector<float> GetAdjustedStrokeArray(IVector<SVGLength> const &value, SVGLength StrokeWidth) {
+  static std::vector<float> GetAdjustedStrokeArray(IVector<SVGLength> const &value, float StrokeWidth) {
     std::vector<float> result;
 
     for (auto const &item : value) {
-      result.push_back(item.Value() / StrokeWidth.Value());
+      /* Win2D sets the length of each dash as the product of the element value in array and stroke width,
+      * we divide each value in the dashArray by StrokeWidth to account for this. 
+      http://microsoft.github.io/Win2D/WinUI2/html/P_Microsoft_Graphics_Canvas_Geometry_CanvasStrokeStyle_CustomDashStyle.htm
+      */
+      result.push_back(item.Value() / StrokeWidth);
     }
 
     return std::move(result);

--- a/windows/RNSVG/Utils.h
+++ b/windows/RNSVG/Utils.h
@@ -19,11 +19,11 @@ using namespace Windows::UI::Text;
 namespace winrt::RNSVG {
 struct Utils {
  public:
-  static std::vector<float> GetValueArray(IVector<SVGLength> const &value) {
+  static std::vector<float> GetAdjustedStrokeArray(IVector<SVGLength> const &value, SVGLength StrokeWidth) {
     std::vector<float> result;
 
     for (auto const &item : value) {
-      result.push_back(item.Value());
+      result.push_back(item.Value() / StrokeWidth.Value());
     }
 
     return std::move(result);


### PR DESCRIPTION
fixes #14 
dashArray example in stroking example page doesn't match other platforms, stroke will need some further work - using #17 to track that. 