### PR TITLE
Add some absolute SVG length conversions and refactor SVGLength related code

### DIFF
--- a/example/examples/Pattern.js
+++ b/example/examples/Pattern.js
@@ -10,6 +10,7 @@ import {
   Defs,
   Pattern,
   Ellipse,
+  Polygon,
 } from 'react-native-svg';
 
 export const PatternPage: React.FunctionComponent<{}> = () => {
@@ -97,6 +98,27 @@ export const PatternPage: React.FunctionComponent<{}> = () => {
             cy="200"
             rx="350"
             ry="150"
+          />
+        </Svg>
+      </Example>
+      <Example title="Star">
+        <Svg width="230" height="100" viewBox="0 0 230 100">
+          <Defs>
+            <Pattern id="star" width="10%" height="10%" viewBox="0 0 10 10">
+              <Polygon
+                points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2"
+                fill="black"
+              />
+            </Pattern>
+          </Defs>
+          <Circle cx="50" cy="50" r="50" fill="url(#star)" />
+          <Circle
+            cx="180"
+            cy="50"
+            r="40"
+            fill="none"
+            strokeWidth="20"
+            stroke="url(#star)"
           />
         </Svg>
       </Example>

--- a/example/examples/Stroking.js
+++ b/example/examples/Stroking.js
@@ -9,34 +9,34 @@ export const StrokingPage: React.FunctionComponent<{}> = () => {
     <Page title="Stroking">
       <Example title="The stroke property defines the color of a line, text or outline of an element">
         <Svg height="80" width="225">
-            <G strokeWidth="1">
+          <G strokeWidth="1">
             <Path stroke="red" d="M5 20 l215 0" />
             <Path stroke="black" d="M5 40 l215 0" />
             <Path stroke="blue" d="M5 60 l215 0" />
-            </G>
+          </G>
         </Svg>
       </Example>
       <Example title="The strokeLinecap property defines different types of endings to an open path">
         <Svg height="80" width="225">
-            <G stroke="red" strokeWidth="8">
+          <G stroke="red" strokeWidth="8">
             <Path strokeLinecap="butt" d="M5 20 l215 0" />
             <Path strokeLinecap="round" d="M5 40 l215 0" />
             <Path strokeLinecap="square" d="M5 60 l215 0" />
-            </G>
+          </G>
         </Svg>
       </Example>
       <Example title="strokeDasharray">
         <Svg height="80" width="225">
-            <G fill="none" stroke="black" strokeWidth="4">
+          <G fill="none" stroke="black" strokeWidth="4">
             <Path strokeDasharray="5,5" d="M5 20 l215 0" />
             <Path strokeDasharray="10,10" d="M5 40 l215 0" />
             <Path strokeDasharray="20,10,5,5,5,10" d="M5 60 l215 0" />
-            </G>
+          </G>
         </Svg>
       </Example>
       <Example title="the strokeDashoffset attribute specifies the distance into the dash pattern to start the dash.">
         <Svg height="80" width="200">
-            <Circle
+          <Circle
             cx="100"
             cy="40"
             r="35"
@@ -45,8 +45,8 @@ export const StrokingPage: React.FunctionComponent<{}> = () => {
             fill="none"
             strokeDasharray="100"
             strokeDashoffset="0"
-            />
-            {/* <Text
+          />
+          {/* <Text
                 stroke="blue"
                 strokeWidth="1"
                 fill="none"
@@ -63,7 +63,7 @@ export const StrokingPage: React.FunctionComponent<{}> = () => {
       </Example>
       <Example title="Advanced stroke example.">
         <Svg height="80" width="200">
-            <Defs>
+          <Defs>
             {/* <RadialGradient
                 id="advanced-stroke-grad"
                 cx="50%"
@@ -78,26 +78,26 @@ export const StrokingPage: React.FunctionComponent<{}> = () => {
              <ClipPath id="advanced-stroke-clip">
                 <Circle r="96" cx="100" cy="40" />
             </ClipPath> */}
-            </Defs>
-            <Rect
-                x="5"
-                y="5"
-                height="70"
-                width="190"
-                fill="blue"
-                stroke="url(#advanced-stroke-grad)"
-                strokeWidth="5"
-                strokeDasharray="10"
-                clipPath="url(#advanced-stroke-clip)"
-            />
-            <Polyline
-                strokeDasharray="20,10,5,5,5,10"
-                points="10,10 20,12 30,20 40,60 60,70 90,55"
-                fill="none"
-                stroke="url(#advanced-stroke-grad)"
-                strokeLinecap="round"
-                strokeWidth="5"
-            />
+          </Defs>
+          <Rect
+            x="5"
+            y="5"
+            height="70"
+            width="190"
+            fill="blue"
+            stroke="url(#advanced-stroke-grad)"
+            strokeWidth="5"
+            strokeDasharray="10"
+            clipPath="url(#advanced-stroke-clip)"
+          />
+          <Polyline
+            strokeDasharray="20,10,5,5,5,10"
+            points="10,10 20,12 30,20 40,60 60,70 90,55"
+            fill="none"
+            stroke="url(#advanced-stroke-grad)"
+            strokeLinecap="round"
+            strokeWidth="5"
+          />
         </Svg>
       </Example>
     </Page>

--- a/windows/RNSVG/CircleView.cpp
+++ b/windows/RNSVG/CircleView.cpp
@@ -32,9 +32,9 @@ void CircleView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate
 void CircleView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
 
-  float cx{Utils::GetSvgLengthValue(m_cx, canvas.Size().Width)};
-  float cy{Utils::GetSvgLengthValue(m_cy, canvas.Size().Height)};
-  float r{Utils::GetSvgLengthValue(m_r, canvas.Size().Height)};
+  float cx{Utils::GetAbsoluteLength(m_cx, canvas.Size().Width)};
+  float cy{Utils::GetAbsoluteLength(m_cy, canvas.Size().Height)};
+  float r{Utils::GetAbsoluteLength(m_r, Utils::GetCanvasDiagonal(canvas.Size()))};
 
   Geometry(Geometry::CanvasGeometry::CreateCircle(resourceCreator, cx, cy, r));
 }

--- a/windows/RNSVG/EllipseView.cpp
+++ b/windows/RNSVG/EllipseView.cpp
@@ -34,10 +34,10 @@ void EllipseView::UpdateProperties(IJSValueReader const &reader, bool forceUpdat
 void EllipseView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
 
-  float cx{Utils::GetSvgLengthValue(m_cx, canvas.Size().Width)};
-  float cy{Utils::GetSvgLengthValue(m_cy, canvas.Size().Height)};
-  float rx{Utils::GetSvgLengthValue(m_rx, canvas.Size().Width)};
-  float ry{Utils::GetSvgLengthValue(m_ry, canvas.Size().Height)};
+  float cx{Utils::GetAbsoluteLength(m_cx, canvas.Size().Width)};
+  float cy{Utils::GetAbsoluteLength(m_cy, canvas.Size().Height)};
+  float rx{Utils::GetAbsoluteLength(m_rx, canvas.Size().Width)};
+  float ry{Utils::GetAbsoluteLength(m_ry, canvas.Size().Height)};
 
   Geometry(Geometry::CanvasGeometry::CreateEllipse(resourceCreator, cx, cy, rx, ry));
 }

--- a/windows/RNSVG/LineView.cpp
+++ b/windows/RNSVG/LineView.cpp
@@ -33,10 +33,10 @@ void LineView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, 
 void LineView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
 
-  float x1{Utils::GetSvgLengthValue(m_x1, canvas.Size().Width)};
-  float y1{Utils::GetSvgLengthValue(m_y1, canvas.Size().Height)};
-  float x2{Utils::GetSvgLengthValue(m_x2, canvas.Size().Width)};
-  float y2{Utils::GetSvgLengthValue(m_y2, canvas.Size().Height)};
+  float x1{Utils::GetAbsoluteLength(m_x1, canvas.Size().Width)};
+  float y1{Utils::GetAbsoluteLength(m_y1, canvas.Size().Height)};
+  float x2{Utils::GetAbsoluteLength(m_x2, canvas.Size().Width)};
+  float y2{Utils::GetAbsoluteLength(m_y2, canvas.Size().Height)};
 
   auto const &pathBuilder{Geometry::CanvasPathBuilder(resourceCreator)};
   pathBuilder.BeginFigure(x1, y1);

--- a/windows/RNSVG/LinearGradientView.cpp
+++ b/windows/RNSVG/LinearGradientView.cpp
@@ -69,10 +69,10 @@ void LinearGradientView::UpdateBounds() {
 }
 
 void LinearGradientView::SetPoints(Brushes::CanvasLinearGradientBrush brush, Windows::Foundation::Rect const &bounds) {
-  float x1{Utils::GetSvgLengthValue(m_x1, bounds.Width) + bounds.X};
-  float y1{Utils::GetSvgLengthValue(m_y1, bounds.Height) + bounds.Y};
-  float x2{Utils::GetSvgLengthValue(m_x2, bounds.Width) + bounds.X};
-  float y2{Utils::GetSvgLengthValue(m_y2, bounds.Height) + bounds.Y};
+  float x1{Utils::GetAbsoluteLength(m_x1, bounds.Width) + bounds.X};
+  float y1{Utils::GetAbsoluteLength(m_y1, bounds.Height) + bounds.Y};
+  float x2{Utils::GetAbsoluteLength(m_x2, bounds.Width) + bounds.X};
+  float y2{Utils::GetAbsoluteLength(m_y2, bounds.Height) + bounds.Y};
 
   brush.StartPoint({x1, y1});
   brush.EndPoint({x2, y2});

--- a/windows/RNSVG/PatternView.cpp
+++ b/windows/RNSVG/PatternView.cpp
@@ -53,6 +53,10 @@ void PatternView::UpdateProperties(IJSValueReader const &reader, bool forceUpdat
   __super::UpdateProperties(reader, forceUpdate, invalidate);
 
   SaveDefinition();
+
+  if (auto const &root{SvgRoot()}) {
+    root.InvalidateCanvas();
+  }
 }
 
 void PatternView::UpdateBounds() {
@@ -87,10 +91,10 @@ void PatternView::CreateBrush(Windows::Foundation::Rect const &rect) {
 }
 
 Windows::Foundation::Rect PatternView::GetAdjustedRect(Windows::Foundation::Rect const &bounds) {
-  float x{Utils::GetSvgLengthValue(m_x, bounds.Width) + bounds.X};
-  float y{Utils::GetSvgLengthValue(m_y, bounds.Height) + bounds.Y};
-  float width{Utils::GetSvgLengthValue(m_width, bounds.Width)};
-  float height{Utils::GetSvgLengthValue(m_height, bounds.Height)};
+  float x{Utils::GetAbsoluteLength(m_x, bounds.Width) + bounds.X};
+  float y{Utils::GetAbsoluteLength(m_y, bounds.Height) + bounds.Y};
+  float width{Utils::GetAbsoluteLength(m_width, bounds.Width)};
+  float height{Utils::GetAbsoluteLength(m_height, bounds.Height)};
 
   return {x, y, width, height};
 }
@@ -121,6 +125,7 @@ Microsoft::Graphics::Canvas::CanvasCommandList PatternView::GetCommandList(Windo
     child.Render(canvas, session);
   }
 
+  session.Close();
   return cmdList;
 }
 

--- a/windows/RNSVG/RNSVG.vcxproj
+++ b/windows/RNSVG/RNSVG.vcxproj
@@ -192,6 +192,7 @@
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ReactPackageProvider.idl" />
+    <Midl Include="Types.idl" />
     <Midl Include="Views.idl">
       <SubType>Designer</SubType>
     </Midl>

--- a/windows/RNSVG/RNSVG.vcxproj.filters
+++ b/windows/RNSVG/RNSVG.vcxproj.filters
@@ -3,10 +3,13 @@
   <ItemGroup>
     <Midl Include="ReactPackageProvider.idl" />
     <Midl Include="Views.idl">
-      <Filter>Views</Filter>
+      <Filter>IDLs</Filter>
     </Midl>
     <Midl Include="ViewManagers.idl">
-      <Filter>ViewManagers</Filter>
+      <Filter>IDLs</Filter>
+    </Midl>
+    <Midl Include="Types.idl">
+      <Filter>IDLs</Filter>
     </Midl>
   </ItemGroup>
   <ItemGroup>
@@ -233,6 +236,9 @@
     </Filter>
     <Filter Include="ViewManagers\GroupViewManagers">
       <UniqueIdentifier>{5942afc3-8b5d-4d8c-bb09-e82581f606b7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IDLs">
+      <UniqueIdentifier>{50f81ae3-d543-477a-a60c-a0f310289f29}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/windows/RNSVG/RectView.cpp
+++ b/windows/RNSVG/RectView.cpp
@@ -40,15 +40,15 @@ void RectView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, 
 void RectView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
 
-  float x{Utils::GetSvgLengthValue(m_x, canvas.Size().Width)};
-  float y{Utils::GetSvgLengthValue(m_y, canvas.Size().Height)};
-  float width{Utils::GetSvgLengthValue(m_width, canvas.Size().Width)};
-  float height{Utils::GetSvgLengthValue(m_height, canvas.Size().Height)};
+  float x{Utils::GetAbsoluteLength(m_x, canvas.Size().Width)};
+  float y{Utils::GetAbsoluteLength(m_y, canvas.Size().Height)};
+  float width{Utils::GetAbsoluteLength(m_width, canvas.Size().Width)};
+  float height{Utils::GetAbsoluteLength(m_height, canvas.Size().Height)};
 
-  auto const &rxLength{m_rx.Unit() == RNSVG::UnitType::Unknown ? m_ry : m_rx};
-  auto const &ryLength{m_ry.Unit() == RNSVG::UnitType::Unknown ? m_rx : m_ry};
-  float rx{Utils::GetSvgLengthValue(rxLength, canvas.Size().Width)};
-  float ry{Utils::GetSvgLengthValue(ryLength, canvas.Size().Height)};
+  auto const &rxLength{m_rx.Unit() == RNSVG::LengthType::Unknown ? m_ry : m_rx};
+  auto const &ryLength{m_ry.Unit() == RNSVG::LengthType::Unknown ? m_rx : m_ry};
+  float rx{Utils::GetAbsoluteLength(rxLength, canvas.Size().Width)};
+  float ry{Utils::GetAbsoluteLength(ryLength, canvas.Size().Height)};
 
   Geometry(Geometry::CanvasGeometry::CreateRoundedRectangle(resourceCreator, x, y, width, height, rx, ry));
 }

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -36,7 +36,7 @@ void RenderableView::UpdateProperties(IJSValueReader const &reader, bool forceUp
     } else if (propertyName == "strokeWidth") {
       prop = RNSVG::BaseProp::StrokeWidth;
       if (forceUpdate || !m_propSetMap[prop]) {
-        auto const &fallbackValue{parent ? parent.StrokeWidth() : RNSVG::SVGLength(1.0f, RNSVG::UnitType::PX)};
+        auto const &fallbackValue{parent ? parent.StrokeWidth() : RNSVG::SVGLength(1.0f, RNSVG::LengthType::Pixel)};
         m_strokeWidth = Utils::JSValueAsSVGLength(propertyValue, fallbackValue);
       }
     } else if (propertyName == "strokeOpacity") {
@@ -222,8 +222,10 @@ void RenderableView::Render(
     strokeStyle.LineJoin(StrokeLineJoin());
     strokeStyle.DashOffset(StrokeDashOffset());
     strokeStyle.MiterLimit(StrokeMiterLimit());
-    float strokeWidth{Utils::GetSvgLengthValue(StrokeWidth(), canvas.Size().Width)};
-    strokeStyle.CustomDashStyle(Utils::GetAdjustedStrokeArray(StrokeDashArray(), strokeWidth));
+
+    float canvasDiagonal{Utils::GetCanvasDiagonal(canvas.Size())};
+    float strokeWidth{Utils::GetAbsoluteLength(StrokeWidth(), canvasDiagonal)};
+    strokeStyle.CustomDashStyle(Utils::GetAdjustedStrokeArray(StrokeDashArray(), strokeWidth, canvasDiagonal));
 
     auto const &stroke{Utils::GetCanvasBrush(StrokeBrushId(), Stroke(), SvgRoot(), geometry, resourceCreator)};
     session.DrawGeometry(geometry, stroke, strokeWidth, strokeStyle);

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -76,7 +76,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   float m_strokeOpacity{1.0f};
   float m_strokeMiterLimit{0.0f};
   float m_strokeDashOffset{0.0f};
-  RNSVG::SVGLength m_strokeWidth{1.0f, RNSVG::UnitType::PX};
+  RNSVG::SVGLength m_strokeWidth{1.0f, RNSVG::LengthType::Pixel};
   Windows::Foundation::Collections::IVector<RNSVG::SVGLength> m_strokeDashArray{
       winrt::single_threaded_vector<RNSVG::SVGLength>()};
   Microsoft::Graphics::Canvas::Geometry::CanvasCapStyle m_strokeLineCap{

--- a/windows/RNSVG/SVGLength.cpp
+++ b/windows/RNSVG/SVGLength.cpp
@@ -5,49 +5,51 @@
 #endif
 
 namespace winrt::RNSVG::implementation {
-SVGLength::SVGLength(float value) : m_value(value), m_unit(RNSVG::UnitType::Number) {}
+SVGLength::SVGLength(float value) : m_value(value), m_unit(RNSVG::LengthType::Number) {}
 
-SVGLength::SVGLength(float value, RNSVG::UnitType type) : m_value(value), m_unit(type) {}
+SVGLength::SVGLength(float value, RNSVG::LengthType type) : m_value(value), m_unit(type) {}
 
 RNSVG::SVGLength SVGLength::From(std::string value) {
   auto strLength{value.size()};
   if (strLength == 0 || value == "normal") {
-    return {0.0, RNSVG::UnitType::Unknown};
+    return {0.0, RNSVG::LengthType::Unknown};
   } else if (value.back() == '%') {
-    return {std::stof(value.substr(0, strLength - 1), nullptr), RNSVG::UnitType::Percentage};
+    return {std::stof(value.substr(0, strLength - 1), nullptr), RNSVG::LengthType::Percentage};
   } else if (strLength > 2) {
     auto end{strLength - 2};
     auto lastTwo{value.substr(end)};
 
-    auto unit{RNSVG::UnitType::Unknown};
+    auto unit{RNSVG::LengthType::Unknown};
     if (lastTwo == "px") {
-      unit = RNSVG::UnitType::Number;
+      unit = RNSVG::LengthType::Number;
     } else if (lastTwo == "em") {
-      unit = RNSVG::UnitType::EMS;
+      unit = RNSVG::LengthType::EMS;
     } else if (lastTwo == "ex") {
-      unit = RNSVG::UnitType::EXS;
-    } else if (lastTwo == "pt") {
-      unit = RNSVG::UnitType::PT;
-    } else if (lastTwo == "pc") {
-      unit = RNSVG::UnitType::PC;
-    } else if (lastTwo == "mm") {
-      unit = RNSVG::UnitType::MM;
+      unit = RNSVG::LengthType::EXS;
     } else if (lastTwo == "cm") {
-      unit = RNSVG::UnitType::CM;
+      unit = RNSVG::LengthType::Centimeter;
+    } else if (lastTwo == "mm") {
+      unit = RNSVG::LengthType::Millimeter;
+    } else if (lastTwo == "in") {
+      unit = RNSVG::LengthType::Inch;
+    } else if (lastTwo == "pt") {
+      unit = RNSVG::LengthType::Point;
+    } else if (lastTwo == "pc") {
+      unit = RNSVG::LengthType::Pica;
     } else {
-      unit = RNSVG::UnitType::Number;
+      unit = RNSVG::LengthType::Number;
       end = strLength;
     }
 
     return {std::stof(value.substr(0, end), nullptr), unit};
   }
 
-  return {std::stof(value, nullptr), RNSVG::UnitType::Number};
+  return {std::stof(value, nullptr), RNSVG::LengthType::Number};
 }
 
 RNSVG::SVGLength SVGLength::From(Microsoft::ReactNative::JSValue const &propertyValue) {
   if (propertyValue.IsNull()) {
-    return {0.0f, RNSVG::UnitType::Unknown};
+    return {0.0f, RNSVG::LengthType::Unknown};
   } else if (propertyValue.Type() == Microsoft::ReactNative::JSValueType::String) {
     return SVGLength::From(propertyValue.AsString());
   } else {

--- a/windows/RNSVG/SVGLength.h
+++ b/windows/RNSVG/SVGLength.h
@@ -9,21 +9,17 @@ struct SVGLength : SVGLengthT<SVGLength> {
  public:
   SVGLength() = default;
   SVGLength(float value);
-  SVGLength(float value, RNSVG::UnitType type);
+  SVGLength(float value, RNSVG::LengthType type);
 
-  float Value() {
-    return m_value;
-  }
-  RNSVG::UnitType Unit() {
-    return m_unit;
-  }
+  float Value() { return m_value; }
+  RNSVG::LengthType Unit() { return m_unit; }
 
   static RNSVG::SVGLength From(std::string value);
   static RNSVG::SVGLength From(Microsoft::ReactNative::JSValue const &value);
 
  private:
   float m_value{0.0f};
-  RNSVG::UnitType m_unit{RNSVG::UnitType::Unknown};
+  RNSVG::LengthType m_unit{RNSVG::LengthType::Unknown};
 };
 } // namespace winrt::RNSVG::implementation
 

--- a/windows/RNSVG/Types.idl
+++ b/windows/RNSVG/Types.idl
@@ -1,0 +1,79 @@
+namespace RNSVG {
+  enum SVGClass {
+    RNSVGGroup,
+    RNSVGPath,
+    RNSVGText,
+    RNSVGTSpan,
+    RNSVGTextPath,
+    RNSVGImage,
+    RNSVGCircle,
+    RNSVGEllipse,
+    RNSVGLine,
+    RNSVGRect,
+    RNSVGClipPath,
+    RNSVGDefs,
+    RNSVGUse,
+    RNSVGSymbol,
+    RNSVGLinearGradient,
+    RNSVGRadialGradient,
+    RNSVGPattern,
+    RNSVGMask,
+    RNSVGMarker,
+    RNSVGForeignObject,
+    Unknown,
+  };
+
+  enum MeetOrSlice {
+    Meet,
+    Slice,
+    None,
+  };
+
+  enum BaseProp {
+    Matrix,
+    Fill,
+    FillOpacity,
+    FillRule,
+    Stroke,
+    StrokeOpacity,
+    StrokeWidth,
+    StrokeMiterLimit,
+    StrokeDashOffset,
+    StrokeDashArray,
+    StrokeLineCap,
+    StrokeLineJoin,
+    Unknown,
+  };
+
+  enum FontProp {
+    FontSize,
+    FontWeight,
+    FontFamily,
+    Unknown,
+  };
+
+  enum LengthType
+  {
+    Unknown,
+    Number,
+    Percentage,
+    EMS,
+    EXS,
+    Pixel,
+    Centimeter,
+    Millimeter,
+    Inch,
+    Point,
+    Pica,
+  };
+
+  [default_interface]
+  runtimeclass SVGLength {
+    SVGLength();
+    SVGLength(Single param);
+    SVGLength(Single param, LengthType type);
+
+    Single Value{ get; };
+    LengthType Unit{ get; };
+  };
+}

--- a/windows/RNSVG/UseView.cpp
+++ b/windows/RNSVG/UseView.cpp
@@ -51,18 +51,18 @@ void UseView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSession
               (symbol.MinX() + symbol.VbWidth()) * root.SvgScale(),
               (symbol.MinY() + symbol.VbHeight()) * root.SvgScale()};
 
-          float elX{Utils::GetSvgLengthValue(m_x, canvas.Size().Width)};
-          float elY{Utils::GetSvgLengthValue(m_y, canvas.Size().Height)};
-          float elWidth{Utils::GetSvgLengthValue(m_width, canvas.Size().Width)};
-          float elHeight{Utils::GetSvgLengthValue(m_height, canvas.Size().Height)};
+          float elX{Utils::GetAbsoluteLength(m_x, canvas.Size().Width)};
+          float elY{Utils::GetAbsoluteLength(m_y, canvas.Size().Height)};
+          float elWidth{Utils::GetAbsoluteLength(m_width, canvas.Size().Width)};
+          float elHeight{Utils::GetAbsoluteLength(m_height, canvas.Size().Height)};
           Rect elRect{elX, elY, elWidth, elHeight};
 
           transform = Utils::GetViewBoxTransform(vbRect, elRect, to_string(symbol.Align()), symbol.MeetOrSlice());
         }
       }
     } else {
-      float x{Utils::GetSvgLengthValue(m_x, canvas.Size().Width)};
-      float y{Utils::GetSvgLengthValue(m_y, canvas.Size().Height)};
+      float x{Utils::GetAbsoluteLength(m_x, canvas.Size().Width)};
+      float y{Utils::GetAbsoluteLength(m_y, canvas.Size().Height)};
       transform = Numerics::make_float3x2_translation({x, y});
     }
 

--- a/windows/RNSVG/ViewManagers.idl
+++ b/windows/RNSVG/ViewManagers.idl
@@ -1,30 +1,7 @@
+import "Types.idl";
+
 namespace RNSVG
 {
-  enum SVGClass
-  {
-    RNSVGGroup,
-    RNSVGPath,
-    RNSVGText,
-    RNSVGTSpan,
-    RNSVGTextPath,
-    RNSVGImage,
-    RNSVGCircle,
-    RNSVGEllipse,
-    RNSVGLine,
-    RNSVGRect,
-    RNSVGClipPath,
-    RNSVGDefs,
-    RNSVGUse,
-    RNSVGSymbol,
-    RNSVGLinearGradient,
-    RNSVGRadialGradient,
-    RNSVGPattern,
-    RNSVGMask,
-    RNSVGMarker,
-    RNSVGForeignObject,
-    Unknown,
-  };
-
   [default_interface]
   runtimeclass SvgViewManager
     : Microsoft.ReactNative.IViewManager
@@ -33,7 +10,7 @@ namespace RNSVG
     , Microsoft.ReactNative.IViewManagerWithChildren
   {
     SvgViewManager();
-  }
+  };
 
   [default_interface]
   unsealed runtimeclass RenderableViewManager
@@ -42,43 +19,43 @@ namespace RNSVG
     , Microsoft.ReactNative.IViewManagerWithNativeProperties
   {
     RenderableViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass RectViewManager : RenderableViewManager
   {
     RectViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass CircleViewManager : RenderableViewManager
   {
     CircleViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass EllipseViewManager : RenderableViewManager
   {
     EllipseViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass LineViewManager : RenderableViewManager
   {
     LineViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass PathViewManager : RenderableViewManager
   {
     PathViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass UseViewManager : RenderableViewManager
   {
     UseViewManager();
-  }
+  };
 
   [default_interface]
   unsealed runtimeclass GroupViewManager
@@ -86,41 +63,41 @@ namespace RNSVG
     , Microsoft.ReactNative.IViewManagerWithChildren
   {
     GroupViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass DefsViewManager : GroupViewManager
   {
     DefsViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass LinearGradientViewManager : GroupViewManager
   {
     LinearGradientViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass PatternViewManager : GroupViewManager
   {
     PatternViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass SymbolViewManager : GroupViewManager
   {
     SymbolViewManager();
-  }
+  };
 
   [default_interface]
   unsealed runtimeclass TextViewManager : GroupViewManager
   {
     TextViewManager();
-  }
+  };
 
   [default_interface]
   runtimeclass TSpanViewManager : TextViewManager
   {
     TSpanViewManager();
-  }
+  };
 }

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -1,35 +1,7 @@
+import "Types.idl";
+
 namespace RNSVG
 {
-  enum UnitType
-  {
-    Unknown,
-    Number,
-    Percentage,
-    EMS,
-    EXS,
-    PX,
-    CM,
-    MM,
-    PT,
-    PC,
-  };
-
-  [default_interface]
-  runtimeclass SVGLength {
-    SVGLength();
-    SVGLength(Single param);
-    SVGLength(Single param, UnitType type);
-
-    Single Value { get; };
-    UnitType Unit { get; };
-  };
-
-  enum MeetOrSlice {
-    Meet,
-    Slice,
-    None,
-  };
-
   [default_interface]
   runtimeclass SvgView : Windows.UI.Xaml.Controls.Panel
   {
@@ -43,31 +15,6 @@ namespace RNSVG
 
     void UpdateProperties(Microsoft.ReactNative.IJSValueReader reader);
     void InvalidateCanvas();
-  };
-
-  enum BaseProp
-  {
-    Matrix,
-    Fill,
-    FillOpacity,
-    FillRule,
-    Stroke,
-    StrokeOpacity,
-    StrokeWidth,
-    StrokeMiterLimit,
-    StrokeDashOffset,
-    StrokeDashArray,
-    StrokeLineCap,
-    StrokeLineJoin,
-    Unknown,
-  };
-
-  enum FontProp
-  {
-    FontSize,
-    FontWeight,
-    FontFamily,
-    Unknown,
   };
 
   [default_interface]
@@ -213,4 +160,4 @@ namespace RNSVG
   {
     PatternView();
   };
-  }
+}


### PR DESCRIPTION
- Split types and enums into their own IDL (Types.idl)
- Renamed UnitType to LengthType
- Added Inches to LengthType
- Renamed Utils::GetSvgLengthValue to Utils::GetAbsoluteLength
- Per [SVG spec](https://oreillymedia.github.io/Using_SVG/guide/units.html), if strokeWidth and Circle's r prop are relative, they are relative to the Canvas' diagonal instead of Width/Height.
- Utils::GetAdjustedStrokeArray now calls Utils::GetAbsoluteLength on each array element first. 
- Added conversion/support for the following length types: in, pc, pt, cm, mm.