### PR TITLE
Fix opacity and Svg -> Children base prop inheritance

### DIFF
--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -44,6 +44,8 @@ struct RenderableView : RenderableViewT<RenderableView> {
   virtual void Unload();
 
  protected:
+  float m_opacity{1.0f};
+
   std::map<RNSVG::BaseProp, bool> m_propSetMap{
       {RNSVG::BaseProp::Matrix, false},
       {RNSVG::BaseProp::Fill, false},
@@ -58,7 +60,6 @@ struct RenderableView : RenderableViewT<RenderableView> {
       {RNSVG::BaseProp::StrokeLineCap, false},
       {RNSVG::BaseProp::StrokeLineJoin, false},
   };
-  float m_opacity{1.0f};
 
  private:
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};

--- a/windows/RNSVG/SvgView.cpp
+++ b/windows/RNSVG/SvgView.cpp
@@ -55,8 +55,6 @@ void SvgView::UpdateProperties(IJSValueReader const &reader) {
       m_align = Utils::JSValueAsString(propertyValue);
     } else if (propertyName == "meetOrSlice") {
       m_meetOrSlice = Utils::GetMeetOrSlice(propertyValue);
-    } else if (propertyName == "opacity") {
-      m_opacity = Utils::JSValueAsFloat(propertyValue, 1.0f);
     }
   }
 
@@ -82,8 +80,6 @@ void SvgView::Canvas_Draw(UI::Xaml::CanvasControl const &sender, UI::Xaml::Canva
     m_hasRendered = true;
   }
 
-  auto layer{args.DrawingSession().CreateLayer(m_opacity)};
-
   if (m_align != "") {
     Rect vbRect{m_minX * m_scale, m_minY * m_scale, m_vbWidth * m_scale, m_vbHeight * m_scale};
     Rect elRect{0, 0, static_cast<float>(sender.ActualWidth()), static_cast<float>(sender.ActualHeight())};
@@ -95,8 +91,6 @@ void SvgView::Canvas_Draw(UI::Xaml::CanvasControl const &sender, UI::Xaml::Canva
     m_group.SaveDefinition();
     m_group.Render(sender, args.DrawingSession());
   }
-
-  layer.Close();
 }
 
 void SvgView::Canvas_SizeChanged(

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -47,7 +47,6 @@ struct SvgView : SvgViewT<SvgView> {
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl m_canvas{};
   RNSVG::GroupView m_group{nullptr};
-  float m_opacity{1.0f};
   float m_scale{0.0f};
   float m_minX{0.0f};
   float m_minY{0.0f};

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -10,10 +10,12 @@ struct SvgView : SvgViewT<SvgView> {
   SvgView(Microsoft::ReactNative::IReactContext const &context);
 
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl Canvas() { return m_canvas; }
+
+  RNSVG::GroupView Group() { return m_group; }
+  void Group(RNSVG::GroupView const &value) { m_group = value; }
+
   float SvgScale() { return m_scale; }
-  Windows::Foundation::Collections::IVector<Windows::UI::Xaml::UIElement> Views() {
-    return m_views;
-  }
+
   Windows::Foundation::Collections::IMap<hstring, RNSVG::RenderableView> Templates() {
     return m_templates;
   }
@@ -44,6 +46,7 @@ struct SvgView : SvgViewT<SvgView> {
   bool m_hasRendered{false};
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl m_canvas{};
+  RNSVG::GroupView m_group{nullptr};
   float m_opacity{1.0f};
   float m_scale{0.0f};
   float m_minX{0.0f};
@@ -52,11 +55,11 @@ struct SvgView : SvgViewT<SvgView> {
   float m_vbHeight{0.0f};
   RNSVG::SVGLength m_bbWidth{};
   RNSVG::SVGLength m_bbHeight{};
+  RNSVG::SVGLength m_width{};
+  RNSVG::SVGLength m_height{};
   std::string m_align{""};
   RNSVG::MeetOrSlice m_meetOrSlice{RNSVG::MeetOrSlice::Meet};
 
-  Windows::Foundation::Collections::IVector<Windows::UI::Xaml::UIElement> m_views{
-      winrt::single_threaded_vector<Windows::UI::Xaml::UIElement>()};
   Windows::Foundation::Collections::IMap<hstring, RNSVG::RenderableView> m_templates{
       winrt::single_threaded_map<hstring, RNSVG::RenderableView>()};
   Windows::Foundation::Collections::IMap<hstring, RNSVG::BrushView> m_brushes{

--- a/windows/RNSVG/SvgViewManager.cpp
+++ b/windows/RNSVG/SvgViewManager.cpp
@@ -65,33 +65,25 @@ void SvgViewManager::UpdateProperties(FrameworkElement const &view, IJSValueRead
 // IViewManagerWithChildren
 void SvgViewManager::AddView(FrameworkElement const &parent, UIElement const &child, int64_t /*index*/) {
   if (auto const &view{parent.try_as<RNSVG::SvgView>()}) {
-    view.Views().Append(child);
 
-    if (auto const &childView{child.try_as<RNSVG::RenderableView>()}) {
-      childView.SvgParent(parent);
+    // Every SvgView has exactly one child - a Group that gets
+    // all of Svg's children piped through.
+    if (auto const &group{child.try_as<RNSVG::GroupView>()}) {
+      group.SvgParent(parent);
     }
   }
 }
 
 void SvgViewManager::RemoveAllChildren(FrameworkElement const &parent) {
-  if (auto const &view{parent.try_as<RNSVG::SvgView>()}) {
-    for (auto const &child : view.Views()) {
-      if (auto const &childView{child.try_as<RNSVG::RenderableView>()}) {
-        childView.SvgParent(nullptr);
-      }
-    }
-    view.Views().Clear();
+  auto const &svgView{parent.try_as<RNSVG::SvgView>()};
+  if (svgView && svgView.Group()) {
+    svgView.Group().Unload();
   }
+  svgView.Group(nullptr);
 }
 
-void SvgViewManager::RemoveChildAt(FrameworkElement const &parent, int64_t index) {
-  if (auto const &view{parent.try_as<RNSVG::SvgView>()}) {
-    auto const &child{view.Views().GetAt(static_cast<uint32_t>(index))};
-    if (auto const &childView{child.try_as<RNSVG::RenderableView>()}) {
-      childView.SvgParent(nullptr);
-    }
-    view.Views().RemoveAt(static_cast<uint32_t>(index));
-  }
+void SvgViewManager::RemoveChildAt(FrameworkElement const &parent, int64_t /*index*/) {
+  RemoveAllChildren(parent);
 }
 
 void SvgViewManager::ReplaceChild(
@@ -99,17 +91,14 @@ void SvgViewManager::ReplaceChild(
     UIElement const &oldChild,
     UIElement const &newChild) {
   auto const &svgView{parent.try_as<RNSVG::SvgView>()};
-  auto const &oldChildView{oldChild.try_as<RNSVG::RenderableView>()};
-  auto const &newChildView{newChild.try_as<RNSVG::RenderableView>()};
+  auto const &oldGroup{oldChild.try_as<RNSVG::GroupView>()};
+  auto const &newGroup{newChild.try_as<RNSVG::GroupView>()};
 
-  if (svgView && oldChildView && newChildView) {
-    uint32_t index;
-
-    if (svgView.Views().IndexOf(oldChild, index)) {
-      svgView.Views().SetAt(index, newChild);
-      oldChildView.SvgParent(nullptr);
-      newChildView.SvgParent(parent);
-    }
+  if (svgView && oldGroup && newGroup) {
+    newGroup.MergeProperties(oldGroup);
+    oldGroup.Unload();
+    newGroup.SvgParent(parent);
+    svgView.Group(newGroup);
   }
 }
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/SvgViewManager.cpp
+++ b/windows/RNSVG/SvgViewManager.cpp
@@ -64,13 +64,14 @@ void SvgViewManager::UpdateProperties(FrameworkElement const &view, IJSValueRead
 
 // IViewManagerWithChildren
 void SvgViewManager::AddView(FrameworkElement const &parent, UIElement const &child, int64_t /*index*/) {
-  if (auto const &view{parent.try_as<RNSVG::SvgView>()}) {
+  auto const &svgView{parent.try_as<RNSVG::SvgView>()};
+  auto const &group{child.try_as<RNSVG::GroupView>()};
 
+  if (svgView && group) {
     // Every SvgView has exactly one child - a Group that gets
     // all of Svg's children piped through.
-    if (auto const &group{child.try_as<RNSVG::GroupView>()}) {
-      group.SvgParent(parent);
-    }
+    group.SvgParent(parent);
+    svgView.Group(group);
   }
 }
 

--- a/windows/RNSVG/SvgViewManager.cpp
+++ b/windows/RNSVG/SvgViewManager.cpp
@@ -43,12 +43,13 @@ IMapView<hstring, ViewManagerPropertyType> SvgViewManager::NativeProps() {
 
   nativeProps.Insert(L"height", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"width", ViewManagerPropertyType::Number);
-  nativeProps.Insert(L"opacity", ViewManagerPropertyType::Number);
+
   // viewBox
   nativeProps.Insert(L"minX", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"minY", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"vbWidth", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"vbHeight", ViewManagerPropertyType::Number);
+
   // preserveAspectRatio
   nativeProps.Insert(L"align", ViewManagerPropertyType::String);
   nativeProps.Insert(L"meetOrSlice", ViewManagerPropertyType::Number);

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -8,8 +8,9 @@ namespace RNSVG
     SvgView(Microsoft.ReactNative.IReactContext context);
 
     Single SvgScale{ get; };
+    GroupView Group;
     Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl Canvas{ get; };
-    Windows.Foundation.Collections.IVector<Windows.UI.Xaml.UIElement> Views{ get; };
+
     Windows.Foundation.Collections.IMap<String, RenderableView> Templates{ get; };
     Windows.Foundation.Collections.IMap<String, BrushView> Brushes{ get; };
 


### PR DESCRIPTION
- Switched SvgView from having a vector of RenderableViews as children, to just having one GroupView.
  - On the javascript side of things, all children of an Svg are wrapped in a G element, so SvgView is guaranteed to only ever have one child. 
  - See [Svg.tsx](https://github.com/marlenecota/react-native-svg/blob/windows/src/elements/Svg.tsx#L196)
  - This is set up for implementing nested SvgViews
- Fixed opacity being too strong when set on the Svg element (#15), and not doing anything when set on any other element other than Use.